### PR TITLE
implémentation config root extra nginx (nginx http avant serverr)

### DIFF
--- a/adm/__make_nginx_conf
+++ b/adm/__make_nginx_conf
@@ -42,6 +42,18 @@ def get_conf(plugin_configuration_file):
     parser.read(plugin_configuration_file)
     apps = [x.replace("app_", "", 1).split(':')[0] for x in parser.sections()
             if x.startswith("app_")]
+
+    extra_root_nginx_conf_string = ""
+    if parser.has_option("root", "extra_nginx_conf_filename"):
+        extra_root_nginx_conf_filename = \
+            parser.get("root", "extra_nginx_conf_filename")
+        if extra_root_nginx_conf_filename != "null":
+            extra_root_nginx_conf_filepath = \
+                os.path.join(os.path.dirname(plugin_configuration_file),
+                             extra_root_nginx_conf_filename)
+            with open(extra_root_nginx_conf_filepath, "r") as f:
+                extra_root_nginx_conf_string = f.read()
+
     extra_general_nginx_conf_string = ""
     if parser.has_option("general", "extra_nginx_conf_filename"):
         extra_general_nginx_conf_filename = \
@@ -52,7 +64,11 @@ def get_conf(plugin_configuration_file):
                              extra_general_nginx_conf_filename)
             with open(extra_general_nginx_conf_filepath, "r") as f:
                 extra_general_nginx_conf_string = f.read()
+
     plugin_conf["name"] = plugin_name
+    plugin_conf["extra_root_nginx_conf_string"] = \
+        envtpl.render_string(extra_root_nginx_conf_string,
+                             extra_variables={"PLUGIN": plugin_conf})
     plugin_conf["extra_general_nginx_conf_string"] = \
         envtpl.render_string(extra_general_nginx_conf_string,
                              extra_variables={"PLUGIN": plugin_conf})

--- a/adm/templates/plugins/default/{{cookiecutter.name}}/config.ini
+++ b/adm/templates/plugins/default/{{cookiecutter.name}}/config.ini
@@ -4,6 +4,22 @@
 #####                         #####
 ###################################
 # (plugin metadatas)
+
+[root]
+
+# !!! ADVANCED SETTING !!!
+# Use this only if you are sure about what you are doing
+# extra nginx configuration filename inside your plugin directory
+# null => no extra configuration
+# The content will be included directly in "http" section before "server"
+# If you want to include some configuration fragments specific to server section
+# don't use this key (in [root] section] but the one in [general] section
+# If you want to include some configuration fragments specific to an app
+# don't use this key (in [root] section] but the one in [app_xxxxx] section
+# Note: this key is not used with virtualdomain_based_routing
+extra_nginx_conf_filename=null
+
+
 [general]
 
 # Name of the plugin
@@ -35,6 +51,8 @@ vendor={{cookiecutter.vendor}}
 # extra nginx configuration filename inside your plugin directory
 # null => no extra configuration
 # The content will be included directly in "server" section
+# If you want to include some configuration fragments specific to "http" section before "server" section
+# don't use this key but the one in [root] section
 # If you want to include some configuration fragments specific to an app
 # don't use this key (in [general] section] but the one in [app_xxxxx] section
 # Note: this key is not used with virtualdomain_based_routing
@@ -78,8 +96,10 @@ static_routing=true
 # extra nginx configuration filename inside your plugin directory
 # null => no extra configuration
 # the content will be included directly in your app "location" section
+# If you want to include some configuration fragments specific to "http" section before "server" section
+# don't use this key but the one in [root] section
 # if you want to include some configuration fragments at a more general level
-# don't use this key but the one in [general] section)
+# don't use this key but the one in [general] section
 # Note: if you use virtualdomain_based_routing, the content will be included
 # in the custom "server" section (specific to your app and not in "location")
 extra_nginx_conf_filename=null

--- a/adm/templates/plugins/node/{{cookiecutter.name}}/config.ini
+++ b/adm/templates/plugins/node/{{cookiecutter.name}}/config.ini
@@ -4,6 +4,21 @@
 #####                         #####
 ###################################
 # (plugin metadatas)
+
+[root]
+# !!! ADVANCED SETTING !!!
+# Use this only if you are sure about what you are doing
+# extra nginx configuration filename inside your plugin directory
+# null => no extra configuration
+# The content will be included directly in "http" section before "server"
+# If you want to include some configuration fragments specific to server section
+# don't use this key (in [root] section] but the one in [general] section
+# If you want to include some configuration fragments specific to an app
+# don't use this key (in [root] section] but the one in [app_xxxxx] section
+# Note: this key is not used with virtualdomain_based_routing
+extra_nginx_conf_filename=null
+
+
 [general]
 
 # Name of the plugin
@@ -35,6 +50,8 @@ vendor={{cookiecutter.vendor}}
 # extra nginx configuration filename inside your plugin directory
 # null => no extra configuration
 # The content will be included directly in "server" section
+# If you want to include some configuration fragments specific to "http" section before "server" section
+# don't use this key but the one in [root] section
 # If you want to include some configuration fragments specific to an app
 # don't use this key (in [general] section] but the one in [app_xxxxx] section
 # Note: this key is not used with virtualdomain_based_routing
@@ -76,8 +93,10 @@ static_routing=true
 # extra nginx configuration filename inside your plugin directory
 # null => no extra configuration
 # the content will be included directly in your app "location" section
+# If you want to include some configuration fragments specific to "http" section before "server" section
+# don't use this key but the one in [root] section
 # if you want to include some configuration fragments at a more general level
-# don't use this key but the one in [general] section)
+# don't use this key but the one in [general] section
 # Note: if you use virtualdomain_based_routing, the content will be included
 # in the custom "server" section (specific to your app and not in "location")
 extra_nginx_conf_filename=null
@@ -89,6 +108,8 @@ extra_nginx_conf_filename=null
 # the content will be included directly in your app "location" section for
 # the "static" routing part (see also extra_nginx_conf_filename key for
 # the "dynamic" part)
+# if you want to include some configuration fragments at http root level
+# don't use this key but the one in [root] section)
 # if you want to include some configuration fragments at a more general level
 # don't use this key but the one in [general] section)
 extra_nginx_conf_static_filename=null

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -59,6 +59,14 @@ http {
         ''      close;
     }
 
+    {% for PLUGIN in PLUGINS %}
+        {% if PLUGIN.extra_root_nginx_conf_string %}
+            ##### BEGIN OF ROOT EXTRA NGINX CONF FOR PLUGIN {{PLUGIN.name}} #####
+            {{PLUGIN.extra_root_nginx_conf_string}}
+            ##### END OF ROOT EXTRA NGINX CONF FOR PLUGIN {{PLUGIN.name}} #####
+        {% endif %}
+    {% endfor %}
+
     server {
 
         {% if MFSERV_NGINX_PORT != "0" %}


### PR DESCRIPTION
Add "root" plugin extra conf for nginx.conf plugin fragments located in http { ... } just before server definition (i.e "init_by_lua_file ..." plugin specific conf can be added)