### PR TITLE
feat: change default configuration

### DIFF
--- a/config/config.ini
+++ b/config/config.ini
@@ -46,7 +46,7 @@ logging=1
 
 [admin]
 # null => no monitoring
-hostname=localhost
+hostname=null
 influxdb_http_port=18086
 
 


### PR DESCRIPTION
The admin/hostname value is now set to null (instead of localhost).

BREAKING CHANGE: no admin module configured by default