### PR TITLE
Custom nginx init_worker_by_lua for plugin

### DIFF
--- a/adm/__make_nginx_conf
+++ b/adm/__make_nginx_conf
@@ -58,7 +58,6 @@ def get_conf(plugin_configuration_file):
     if os.path.exists(extra_lua_filepath):
         with open(extra_lua_filepath, 'r') as f:
             extra_lua_nginx_conf_string = f.read()
-            f.close()
     
     extra_root_nginx_conf_string = ""
     if parser.has_option("root", "extra_nginx_conf_filename"):
@@ -70,7 +69,6 @@ def get_conf(plugin_configuration_file):
                              extra_root_nginx_conf_filename)
             with open(extra_root_nginx_conf_filepath, "r") as f:
                 extra_root_nginx_conf_string = f.read()
-                f.close()
 
     extra_general_nginx_conf_string = ""
     if parser.has_option("general", "extra_nginx_conf_filename"):
@@ -82,7 +80,6 @@ def get_conf(plugin_configuration_file):
                              extra_general_nginx_conf_filename)
             with open(extra_general_nginx_conf_filepath, "r") as f:
                 extra_general_nginx_conf_string = f.read()
-                f.close()
 
     plugin_conf["name"] = plugin_name
     plugin_conf["extra_lua_nginx_conf_string"] = \
@@ -109,7 +106,6 @@ def get_conf(plugin_configuration_file):
                                  extra_nginx_conf_filename)
                 with open(extra_nginx_conf_filepath, "r") as f:
                     extra_nginx_conf_string = f.read()
-                    f.close()
         extra_nginx_conf_static_string = ""
         if parser.has_option(section, "extra_nginx_conf_static_filename"):
             extra_nginx_conf_static_filename = \
@@ -120,7 +116,6 @@ def get_conf(plugin_configuration_file):
                                  extra_nginx_conf_static_filename)
                 with open(extra_nginx_conf_static_filepath, "r") as f:
                     extra_nginx_conf_static_string = f.read()
-                    f.close()
         static_routing = True
         if parser.has_option(section, "static_routing"):
             static_routing = parser.getboolean(section, "static_routing")

--- a/adm/__make_nginx_conf
+++ b/adm/__make_nginx_conf
@@ -38,21 +38,39 @@ def get_conf(plugin_configuration_file):
     plugin_conf = {}
     parser = ExtendedConfigParser(config=CONFIG, strict=False,
                                   inheritance='im', interpolation=None)
-    plugin_name = os.path.basename(os.path.dirname(plugin_configuration_file))
+
+    plugin_directory = os.path.dirname(plugin_configuration_file)
+    plugin_name = os.path.basename(plugin_directory)
+
     parser.read(plugin_configuration_file)
     apps = [x.replace("app_", "", 1).split(':')[0] for x in parser.sections()
             if x.startswith("app_")]
 
+    '''
+    if init_worker_by_lua.lua file exists in plugin_directory
+    then this specific lua configuration will be added to
+    init_by_worker_by part after stats (see templates)
+
+    extra_lua_nginx_conf will be added to plugin_conf[...]
+    '''
+    extra_lua_nginx_conf_string = "" 
+    extra_lua_filepath = os.path.join(plugin_directory, 'init_worker_by_lua.lua')
+    if os.path.exists(extra_lua_filepath):
+        with open(extra_lua_filepath, 'r') as f:
+            extra_lua_nginx_conf_string = f.read()
+            f.close()
+    
     extra_root_nginx_conf_string = ""
     if parser.has_option("root", "extra_nginx_conf_filename"):
         extra_root_nginx_conf_filename = \
             parser.get("root", "extra_nginx_conf_filename")
         if extra_root_nginx_conf_filename != "null":
             extra_root_nginx_conf_filepath = \
-                os.path.join(os.path.dirname(plugin_configuration_file),
+                os.path.join(plugin_directory,
                              extra_root_nginx_conf_filename)
             with open(extra_root_nginx_conf_filepath, "r") as f:
                 extra_root_nginx_conf_string = f.read()
+                f.close()
 
     extra_general_nginx_conf_string = ""
     if parser.has_option("general", "extra_nginx_conf_filename"):
@@ -60,12 +78,16 @@ def get_conf(plugin_configuration_file):
             parser.get("general", "extra_nginx_conf_filename")
         if extra_general_nginx_conf_filename != "null":
             extra_general_nginx_conf_filepath = \
-                os.path.join(os.path.dirname(plugin_configuration_file),
+                os.path.join(plugin_directory,
                              extra_general_nginx_conf_filename)
             with open(extra_general_nginx_conf_filepath, "r") as f:
                 extra_general_nginx_conf_string = f.read()
+                f.close()
 
     plugin_conf["name"] = plugin_name
+    plugin_conf["extra_lua_nginx_conf_string"] = \
+        envtpl.render_string(extra_lua_nginx_conf_string,
+                             extra_variables={"PLUGIN": plugin_conf})
     plugin_conf["extra_root_nginx_conf_string"] = \
         envtpl.render_string(extra_root_nginx_conf_string,
                              extra_variables={"PLUGIN": plugin_conf})
@@ -83,20 +105,22 @@ def get_conf(plugin_configuration_file):
                                                    "extra_nginx_conf_filename")
             if extra_nginx_conf_filename != "null":
                 extra_nginx_conf_filepath = \
-                    os.path.join(os.path.dirname(plugin_configuration_file),
+                    os.path.join(plugin_directory,
                                  extra_nginx_conf_filename)
                 with open(extra_nginx_conf_filepath, "r") as f:
                     extra_nginx_conf_string = f.read()
+                    f.close()
         extra_nginx_conf_static_string = ""
         if parser.has_option(section, "extra_nginx_conf_static_filename"):
             extra_nginx_conf_static_filename = \
                 parser.get(section, "extra_nginx_conf_static_filename")
             if extra_nginx_conf_static_filename != "null":
                 extra_nginx_conf_static_filepath = \
-                    os.path.join(os.path.dirname(plugin_configuration_file),
+                    os.path.join(plugin_directory,
                                  extra_nginx_conf_static_filename)
                 with open(extra_nginx_conf_static_filepath, "r") as f:
                     extra_nginx_conf_static_string = f.read()
+                    f.close()
         static_routing = True
         if parser.has_option(section, "static_routing"):
             static_routing = parser.getboolean(section, "static_routing")

--- a/adm/__make_nginx_conf
+++ b/adm/__make_nginx_conf
@@ -42,6 +42,18 @@ def get_conf(plugin_configuration_file):
     parser.read(plugin_configuration_file)
     apps = [x.replace("app_", "", 1).split(':')[0] for x in parser.sections()
             if x.startswith("app_")]
+
+    extra_root_nginx_conf_string = ""
+    if parser.has_option("root", "extra_nginx_conf_filename"):
+        extra_root_nginx_conf_filename = \
+            parser.get("root", "extra_nginx_conf_filename")
+        if extra_root_nginx_conf_filename != "null":
+            extra_root_nginx_conf_filepath = \
+                os.path.join(os.path.dirname(plugin_configuration_file),
+                             extra_root_nginx_conf_filename)
+            with open(extra_root_nginx_conf_filepath, "r") as f:
+                extra_root_nginx_conf_string = f.read()
+
     extra_general_nginx_conf_string = ""
     if parser.has_option("general", "extra_nginx_conf_filename"):
         extra_general_nginx_conf_filename = \
@@ -52,7 +64,11 @@ def get_conf(plugin_configuration_file):
                              extra_general_nginx_conf_filename)
             with open(extra_general_nginx_conf_filepath, "r") as f:
                 extra_general_nginx_conf_string = f.read()
+
     plugin_conf["name"] = plugin_name
+    plugin_conf["extra_root_nginx_conf_string"] = \
+        envtpl.render_string(extra_root_nginx_conf_string,
+                             extra_variables={"PLUGIN": plugin_conf})
     plugin_conf["extra_general_nginx_conf_string"] = \
         envtpl.render_string(extra_general_nginx_conf_string,
                              extra_variables={"PLUGIN": plugin_conf})

--- a/adm/templates/plugins/default/{{cookiecutter.name}}/config.ini
+++ b/adm/templates/plugins/default/{{cookiecutter.name}}/config.ini
@@ -4,6 +4,22 @@
 #####                         #####
 ###################################
 # (plugin metadatas)
+
+[root]
+
+# !!! ADVANCED SETTING !!!
+# Use this only if you are sure about what you are doing
+# extra nginx configuration filename inside your plugin directory
+# null => no extra configuration
+# The content will be included directly in "http" section before "server"
+# If you want to include some configuration fragments specific to server section
+# don't use this key (in [root] section] but the one in [general] section
+# If you want to include some configuration fragments specific to an app
+# don't use this key (in [root] section] but the one in [app_xxxxx] section
+# Note: this key is not used with virtualdomain_based_routing
+extra_nginx_conf_filename=null
+
+
 [general]
 
 # Name of the plugin
@@ -35,6 +51,8 @@ vendor={{cookiecutter.vendor}}
 # extra nginx configuration filename inside your plugin directory
 # null => no extra configuration
 # The content will be included directly in "server" section
+# If you want to include some configuration fragments specific to "http" section before "server" section
+# don't use this key but the one in [root] section
 # If you want to include some configuration fragments specific to an app
 # don't use this key (in [general] section] but the one in [app_xxxxx] section
 # Note: this key is not used with virtualdomain_based_routing
@@ -78,8 +96,10 @@ static_routing=true
 # extra nginx configuration filename inside your plugin directory
 # null => no extra configuration
 # the content will be included directly in your app "location" section
+# If you want to include some configuration fragments specific to "http" section before "server" section
+# don't use this key but the one in [root] section
 # if you want to include some configuration fragments at a more general level
-# don't use this key but the one in [general] section)
+# don't use this key but the one in [general] section
 # Note: if you use virtualdomain_based_routing, the content will be included
 # in the custom "server" section (specific to your app and not in "location")
 extra_nginx_conf_filename=null

--- a/adm/templates/plugins/node/{{cookiecutter.name}}/config.ini
+++ b/adm/templates/plugins/node/{{cookiecutter.name}}/config.ini
@@ -4,6 +4,21 @@
 #####                         #####
 ###################################
 # (plugin metadatas)
+
+[root]
+# !!! ADVANCED SETTING !!!
+# Use this only if you are sure about what you are doing
+# extra nginx configuration filename inside your plugin directory
+# null => no extra configuration
+# The content will be included directly in "http" section before "server"
+# If you want to include some configuration fragments specific to server section
+# don't use this key (in [root] section] but the one in [general] section
+# If you want to include some configuration fragments specific to an app
+# don't use this key (in [root] section] but the one in [app_xxxxx] section
+# Note: this key is not used with virtualdomain_based_routing
+extra_nginx_conf_filename=null
+
+
 [general]
 
 # Name of the plugin
@@ -35,6 +50,8 @@ vendor={{cookiecutter.vendor}}
 # extra nginx configuration filename inside your plugin directory
 # null => no extra configuration
 # The content will be included directly in "server" section
+# If you want to include some configuration fragments specific to "http" section before "server" section
+# don't use this key but the one in [root] section
 # If you want to include some configuration fragments specific to an app
 # don't use this key (in [general] section] but the one in [app_xxxxx] section
 # Note: this key is not used with virtualdomain_based_routing
@@ -76,8 +93,10 @@ static_routing=true
 # extra nginx configuration filename inside your plugin directory
 # null => no extra configuration
 # the content will be included directly in your app "location" section
+# If you want to include some configuration fragments specific to "http" section before "server" section
+# don't use this key but the one in [root] section
 # if you want to include some configuration fragments at a more general level
-# don't use this key but the one in [general] section)
+# don't use this key but the one in [general] section
 # Note: if you use virtualdomain_based_routing, the content will be included
 # in the custom "server" section (specific to your app and not in "location")
 extra_nginx_conf_filename=null
@@ -89,6 +108,8 @@ extra_nginx_conf_filename=null
 # the content will be included directly in your app "location" section for
 # the "static" routing part (see also extra_nginx_conf_filename key for
 # the "dynamic" part)
+# if you want to include some configuration fragments at http root level
+# don't use this key but the one in [root] section)
 # if you want to include some configuration fragments at a more general level
 # don't use this key but the one in [general] section)
 extra_nginx_conf_static_filename=null

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -59,6 +59,14 @@ http {
         ''      close;
     }
 
+    {% for PLUGIN in PLUGINS %}
+        {% if PLUGIN.extra_root_nginx_conf_string %}
+            ##### BEGIN OF ROOT EXTRA NGINX CONF FOR PLUGIN {{PLUGIN.name}} #####
+            {{PLUGIN.extra_root_nginx_conf_string}}
+            ##### END OF ROOT EXTRA NGINX CONF FOR PLUGIN {{PLUGIN.name}} #####
+        {% endif %}
+    {% endfor %}
+
     server {
 
         {% if MFSERV_NGINX_PORT != "0" %}

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -42,6 +42,16 @@ http {
         init_worker_by_lua_block {
             local stats = require("stats")
             stats.init({host="127.0.0.1", port={{MFSERV_TELEGRAF_STATSD_PORT}}, delay=10})
+
+            {% for PLUGIN in PLUGINS %}
+                {% if PLUGIN.extra_lua_nginx_conf_string %}
+                    ##### BEGIN OF LUA EXTRA NGINX CONF FOR PLUGIN {{PLUGIN.name}} #####
+                    try {
+                        {{PLUGIN.extra_lua_nginx_conf_string}}
+                    } @fallback;
+                    ##### END OF LUA EXTRA NGINX CONF FOR PLUGIN {{PLUGIN.name}} #####
+                {% endif %}
+            {% endfor %}
         }
     {% endif %}
 

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -46,9 +46,7 @@ http {
             {% for PLUGIN in PLUGINS %}
                 {% if PLUGIN.extra_lua_nginx_conf_string %}
                     ##### BEGIN OF LUA EXTRA NGINX CONF FOR PLUGIN {{PLUGIN.name}} #####
-                    try {
-                        {{PLUGIN.extra_lua_nginx_conf_string}}
-                    } @fallback;
+                    {{PLUGIN.extra_lua_nginx_conf_string}}
                     ##### END OF LUA EXTRA NGINX CONF FOR PLUGIN {{PLUGIN.name}} #####
                 {% endif %}
             {% endfor %}


### PR DESCRIPTION
Adding custom nginx in init_worker_by_lua {...} if "init_worker_by_lua.lua" file exists inside plugin directory.

...
Remove f.close() with 'with open statement as f' and remove try {..} @fallback init init_worker_by_lua (not in lua syntaxe but nginx