### PR TITLE
feat: add a redis_service option

### DIFF
--- a/adm/_make_circus_conf
+++ b/adm/_make_circus_conf
@@ -9,6 +9,8 @@ MFSERV_PLUGINS_HOME = os.path.join(os.environ["MODULE_RUNTIME_HOME"],
                                    "var", "plugins")
 LOG_LEVEL = os.environ.get('MFSERV_LOG_DEFAULT_LEVEL', 'INFO')
 CONFIG = os.environ.get('MFCONFIG', 'GENERIC')
+MODULE_RUNTIME_HOME = os.environ["MODULE_RUNTIME_HOME"]
+MODULE_HOME = os.environ["MODULE_HOME"]
 
 '''
 Below are defined process types depending on the code language
@@ -43,6 +45,10 @@ def make_watcher_conf(plugin_configuration_file):
             if x.startswith("app_")]
     os.environ["MFSERV_CURRENT_PLUGIN_DIR"] = \
         "%s/%s" % (MFSERV_PLUGINS_HOME, plugin_name)
+
+    redis_service = False
+    if parser.has_option("general", "redis_service"):
+        redis_service = parser.getboolean("general", "redis_service")
 
     # gunicorn_log_level
     gunicorn_log_level = LOG_LEVEL.lower()
@@ -188,6 +194,31 @@ def make_watcher_conf(plugin_configuration_file):
         output.append("stderr_stream.filename = "
                       "{{MODULE_RUNTIME_HOME}}/log/"
                       "app_%s_%s.stderr" % (plugin_name, app))
+    if redis_service:
+        output.append("")
+        output.append("[watcher:redis_service_for_plugin_%s]" % plugin_name)
+        output.append("cmd = redis-server")
+        output.append("args = {{MODULE_RUNTIME_HOME}}/tmp/config_auto/"
+                      "redis_plugin_%s.conf" % plugin_name)
+        output.append("numprocesses = 1")
+        output.append("stdout_stream.class = FileStream")
+        output.append("stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/"
+                      "redis_plugin_%s.log" % plugin_name)
+        output.append("stderr.class = FileStream")
+        output.append("stderr.filename = {{MODULE_RUNTIME_HOME}}/log/"
+                      "redis_plugin_%s.log" % plugin_name)
+        output.append("copy_env = True")
+        output.append("autostart = True")
+        output.append("respawn = True")
+        with open("%s/tmp/config_auto/redis_plugin_%s.conf" %
+                  (MODULE_RUNTIME_HOME, plugin_name), "w+") as f:
+            with open("%s/config/redis_plugin_xxx.conf" % MODULE_HOME,
+                      "r") as f2:
+                content = f2.read()
+            new_content = envtpl.render_string(content,
+                                               {"PLUGIN_NAME": plugin_name})
+            f.write(new_content)
+
     return envtpl.render_string("\n".join(output))
 
 

--- a/adm/templates/plugins/default/{{cookiecutter.name}}/.layerapi2_extra_env
+++ b/adm/templates/plugins/default/{{cookiecutter.name}}/.layerapi2_extra_env
@@ -1,0 +1,1 @@
+REDIS_SOCKET_UNIX_SOCKET_PATH={MODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket

--- a/adm/templates/plugins/default/{{cookiecutter.name}}/config.ini
+++ b/adm/templates/plugins/default/{{cookiecutter.name}}/config.ini
@@ -40,6 +40,12 @@ vendor={{cookiecutter.vendor}}
 # Note: this key is not used with virtualdomain_based_routing
 extra_nginx_conf_filename=null
 
+# If you need a redis instance for your plugin for basic needs (no persistence,
+# max of 0.5GB of memory), you can set redis_service key to 1.
+# To connect to your instance, use an unix socket connection to
+# the value of REDIS_SOCKET_UNIX_SOCKET_PATH env var.
+redis_service=0
+
 
 [app_main]
 

--- a/adm/templates/plugins/node/{{cookiecutter.name}}/.layerapi2_extra_env
+++ b/adm/templates/plugins/node/{{cookiecutter.name}}/.layerapi2_extra_env
@@ -1,0 +1,1 @@
+REDIS_SOCKET_UNIX_SOCKET_PATH={MODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket

--- a/adm/templates/plugins/node/{{cookiecutter.name}}/config.ini
+++ b/adm/templates/plugins/node/{{cookiecutter.name}}/config.ini
@@ -40,6 +40,12 @@ vendor={{cookiecutter.vendor}}
 # Note: this key is not used with virtualdomain_based_routing
 extra_nginx_conf_filename=null
 
+# If you need a redis instance for your plugin for basic needs (no persistence,
+# max of 0.5GB of memory), you can set redis_service key to 1.
+# To connect to your instance, use an unix socket connection to
+# the value of REDIS_SOCKET_UNIX_SOCKET_PATH env var.
+redis_service=0
+
 
 [app_main]
 

--- a/config/Makefile
+++ b/config/Makefile
@@ -1,4 +1,4 @@
-CONFIGS=config.ini nginx.conf
+CONFIGS=config.ini nginx.conf redis_plugin_xxx.conf
 
 include ../adm/root.mk
 include $(MFEXT_HOME)/share/subdir_root.mk

--- a/config/redis_plugin_xxx.conf
+++ b/config/redis_plugin_xxx.conf
@@ -1,0 +1,13 @@
+include {{MFEXT_HOME}}/opt/core/share/redis.conf
+
+pidfile ""
+port 0
+tcp-backlog 40000
+timeout 600
+tcp-keepalive 10
+save ""
+dbfilename redis_plugin_{{PLUGIN_NAME}}.rdb
+dir {{MODULE_RUNTIME_HOME}}/var/
+unixsocket {{MODULE_RUNTIME_HOME}}/var/redis_plugin_{{PLUGIN_NAME}}.socket
+maxmemory 512mb
+maxmemory-policy allkeys-lru


### PR DESCRIPTION
With this option, you can have a dedicated redis instance for your
plugin. It can be used for cache for example but not for storing states
(it's the job of the mfbase module). So you have hard limits on memory
usage for this instance, unix-socket only usage, no persistance. A
special env var REDIS_SOCKET_UNIX_SOCKET_PATH is injected into your
plugin environnement with the fullpath of your plugin redis unix socket.

Close #5