### PR TITLE
nginx.conf lua_package_path with plugin directory paths if lua files

### DIFF
--- a/adm/__make_nginx_conf
+++ b/adm/__make_nginx_conf
@@ -38,24 +38,42 @@ def get_conf(plugin_configuration_file):
     plugin_conf = {}
     parser = ExtendedConfigParser(config=CONFIG, strict=False,
                                   inheritance='im', interpolation=None)
-    plugin_name = os.path.basename(os.path.dirname(plugin_configuration_file))
+
+    plugin_directory = os.path.dirname(plugin_configuration_file)
+    plugin_name = os.path.basename(plugin_directory)
+
+    '''
+    lua_package_path_conf_string if *.lua files inside plugin directory
+    '''
+    lua_package_path_conf_string = ""
+    if len(glob.glob(os.path.join(plugin_directory, '*.lua'))) > 0:
+        lua_package_path_conf_string = os.path.join(
+            os.environ['MODULE_RUNTIME_HOME'], 'var', 'plugins', plugin_name)
+        lua_package_path_conf_string += "/?.lua"
+
     parser.read(plugin_configuration_file)
     apps = [x.replace("app_", "", 1).split(':')[0] for x in parser.sections()
             if x.startswith("app_")]
+
     extra_general_nginx_conf_string = ""
     if parser.has_option("general", "extra_nginx_conf_filename"):
         extra_general_nginx_conf_filename = \
             parser.get("general", "extra_nginx_conf_filename")
         if extra_general_nginx_conf_filename != "null":
             extra_general_nginx_conf_filepath = \
-                os.path.join(os.path.dirname(plugin_configuration_file),
+                os.path.join(plugin_directory,
                              extra_general_nginx_conf_filename)
             with open(extra_general_nginx_conf_filepath, "r") as f:
                 extra_general_nginx_conf_string = f.read()
+
     plugin_conf["name"] = plugin_name
+    plugin_conf["lua_package_path_conf_string"] = \
+        envtpl.render_string(lua_package_path_conf_string,
+                             extra_variables={"PLUGIN": plugin_conf})
     plugin_conf["extra_general_nginx_conf_string"] = \
         envtpl.render_string(extra_general_nginx_conf_string,
                              extra_variables={"PLUGIN": plugin_conf})
+    
     for app in apps:
         section = "app_%s" % app
         typ = parser.get(section, "type")
@@ -67,7 +85,7 @@ def get_conf(plugin_configuration_file):
                                                    "extra_nginx_conf_filename")
             if extra_nginx_conf_filename != "null":
                 extra_nginx_conf_filepath = \
-                    os.path.join(os.path.dirname(plugin_configuration_file),
+                    os.path.join(plugin_directory,
                                  extra_nginx_conf_filename)
                 with open(extra_nginx_conf_filepath, "r") as f:
                     extra_nginx_conf_string = f.read()
@@ -77,7 +95,7 @@ def get_conf(plugin_configuration_file):
                 parser.get(section, "extra_nginx_conf_static_filename")
             if extra_nginx_conf_static_filename != "null":
                 extra_nginx_conf_static_filepath = \
-                    os.path.join(os.path.dirname(plugin_configuration_file),
+                    os.path.join(plugin_directory,
                                  extra_nginx_conf_static_filename)
                 with open(extra_nginx_conf_static_filepath, "r") as f:
                     extra_nginx_conf_static_string = f.read()
@@ -136,10 +154,25 @@ for config_file in glob.glob(MFSERV_PLUGINS_HOME + "/*/config.ini"):
     plugin_conf = get_conf(config_file)
     plugins.append(plugin_conf)
 
+'''
+Building 'lua_package_path' with mfserv, mfcom adding plugins.'
+'''
+mfserv_home_config_lua = os.environ["MFSERV_HOME"] + "/config/?.lua"
+mfcom_home_config_lua = os.environ["MFCOM_HOME"] + "/config/?.lua"
+lua_package_path = mfserv_home_config_lua + ";" + mfcom_home_config_lua
+for plugin in plugins:
+    lua_package_path += ";" + plugin["lua_package_path_conf_string"]
+lua_package_path += ";;"
+
 nginx_conf_file = os.path.join(os.environ['MODULE_HOME'], 'config',
                                'nginx.conf')
 with open(nginx_conf_file, "r") as f:
-    content = envtpl.render_string(f.read(),
-                                   extra_variables={"PLUGINS": plugins})
+    kwargs = {
+        "extra_variables": {
+            "PLUGINS": plugins,
+            "LUA_PACKAGE_PATH": lua_package_path
+        }
+    }
+    content = envtpl.render_string(f.read(), **kwargs)
 
 print(content)

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -35,7 +35,7 @@ http {
     proxy_set_header X-Forwarded-Proto $proxy_x_forwarded_proto;
     proxy_set_header X-Forwarded-Path $request_uri;
 
-    lua_package_path '{{MFSERV_HOME}}/config/?.lua;{{MFCOM_HOME}}/lib/?.lua;;';
+    lua_package_path '{{LUA_PACKAGE_PATH}}';
     lua_code_cache on;
 
     {% if MFSERV_ADMIN_HOSTNAME != "null" %}


### PR DESCRIPTION
Capability for extra_nginx_conf to require lua files for a plug-in (ex: content_by_lua_block for instance, in specific apps locations)

nginx.conf "lua_package_path" will contain /home/mfserv/var/plugins/<plugin_directory> if one or more *.lua files exist in this directory.

 