### PR TITLE
fix: better plugin routing

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -110,7 +110,23 @@ http {
                             }
                         {% endif %}
 
-                        location ~ ^{{PREFIX}} {
+                        location ~ ^{{PREFIX}}/ {
+                            proxy_pass http://unix:{{APP.socket}};
+                            {% if APP.extra_nginx_conf_string %}
+                                ##### BEGIN OF PLUGIN EXTRA NGINX CONF (DYNAMIC) FOR APP {{APP.name}} #####
+                                {{APP.extra_nginx_conf_string}}
+                                ##### END OF PLUGIN EXTRA NGINX CONF (DYNAMIC) FOR APP {{APP.name}} #####
+                            {% endif %}
+                            {% if MFSERV_ADMIN_HOSTNAME != "null" %}
+                                log_by_lua_block {
+                                    local stats = require("stats")
+                                    stats.send_status_code_stat("request_counter", "{{PLUGIN.name}}", "{{APP.app_name}}", "dynamic")
+                                    stats.send_timing_stat("request_timer", "{{PLUGIN.name}}", "{{APP.app_name}}", "dynamic")
+                                }
+                            {% endif %}
+                        }
+
+                        location = {{PREFIX}} {
                             proxy_pass http://unix:{{APP.socket}};
                             {% if APP.extra_nginx_conf_string %}
                                 ##### BEGIN OF PLUGIN EXTRA NGINX CONF (DYNAMIC) FOR APP {{APP.name}} #####


### PR DESCRIPTION
The problem was when a plugin name starts with a string which
is also another plugin name.