### PR TITLE
fix: remove a warning in nginx logs

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -67,14 +67,14 @@ http {
         server_name 127.0.0.1;
 
         location ~ ^/status$ {
-            allow 127.0.0.1/24;
+            allow 127.0.0.1/32;
             deny all;
             stub_status on;
             access_log off;
         }
 
         location ~ ^/uuid$ {
-            allow 127.0.0.1/24;
+            allow 127.0.0.1/32;
             deny all;
             echo "{{UUID}}";
             access_log off;


### PR DESCRIPTION
Close #72 