### PR TITLE
Add all MODULE-named environment varaiables into nginx.conf

### DIFF
--- a/adm/__make_nginx_conf
+++ b/adm/__make_nginx_conf
@@ -167,10 +167,19 @@ lua_package_paths = \
 
 nginx_conf_file = os.path.join(os.environ['MODULE_HOME'], 'config',
                                'nginx.conf')
+
+# add all MODULE-named environment variables to nginx.conf
+list_module_environment = []
+module = os.environ['MODULE']
+for key in os.environ.keys():
+    if key.startswith(module + '_'):
+        list_module_environment.append(key)
+
 with open(nginx_conf_file, "r") as f:
     extra_variables = {
         "PLUGINS": plugins,
-        "LUA_PACKAGE_PATH": ";".join(lua_package_paths) + ";;"
+        "LUA_PACKAGE_PATH": ";".join(lua_package_paths) + ";;",
+        "MODULE_ENVIRONMENT": list_module_environment
     }
     content = envtpl.render_string(f.read(), extra_variables=extra_variables)
 

--- a/adm/__make_nginx_conf
+++ b/adm/__make_nginx_conf
@@ -179,7 +179,8 @@ with open(nginx_conf_file, "r") as f:
     extra_variables = {
         "PLUGINS": plugins,
         "LUA_PACKAGE_PATH": ";".join(lua_package_paths) + ";;",
-        "MODULE_ENVIRONMENT": list_module_environment
+        "MODULE_ENVIRONMENT": [x for x in os.environ.keys() 
+                               if x.startswith("MFSERV_")]
     }
     content = envtpl.render_string(f.read(), extra_variables=extra_variables)
 

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -13,6 +13,10 @@ events {
     worker_connections  10000;
 }
 
+{% for item in MODULE_ENVIRONMENT %}
+env {{item}};
+{%- endfor %}
+
 # HTTP Configuration
 http {
 


### PR DESCRIPTION
Add all MODULE-named environment varaiables into nginx.conf:
lua codes will be able to 'getenv("MFSERV_...")'