### PR TITLE
[WIP] feat: Changes in management of layer dependencies and metapackage names

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -178,4 +178,4 @@ matrix:
     - centos6
     - centos7
 
-branches: [ master, integration, ci_*, pci_*, release_* ]
+branches: [ master, integration, experimental*, ci_*, pci_*, release_* ]

--- a/.layerapi2_dependencies
+++ b/.layerapi2_dependencies
@@ -1,0 +1,4 @@
+root@mfcom
+#+python3_circus@mfext
+openresty@mfext
+#+rpm@mfext

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,6 @@ MODULE_LOWERCASE=mfserv
 -include $(MFEXT_HOME)/share/main_root.mk
 
 all:: directories
-	echo "root@mfcom" >$(MFSERV_HOME)/.layerapi2_dependencies
-	echo "openresty@mfext" >>$(MFSERV_HOME)/.layerapi2_dependencies
 	cd adm && $(MAKE)
 	cd config && $(MAKE)
 	cd layers && $(MAKE)

--- a/layers/layer1_python2/.layerapi2_dependencies
+++ b/layers/layer1_python2/.layerapi2_dependencies
@@ -1,2 +1,1 @@
 python2@mfcom
-root@mfserv

--- a/layers/layer1_python3/.layerapi2_dependencies
+++ b/layers/layer1_python3/.layerapi2_dependencies
@@ -1,2 +1,1 @@
-root@mfserv
 python3@mfcom

--- a/layers/layer9_default/.layerapi2_dependencies
+++ b/layers/layer9_default/.layerapi2_dependencies
@@ -1,0 +1,3 @@
+root@mfserv
+python@mfserv
+default@mfcom

--- a/layers/layer9_default/.layerapi2_label
+++ b/layers/layer9_default/.layerapi2_label
@@ -1,0 +1,1 @@
+default@mfserv

--- a/layers/layer9_default/Makefile
+++ b/layers/layer9_default/Makefile
@@ -1,0 +1,2 @@
+include ../../adm/root.mk
+include $(MFEXT_HOME)/share/layer.mk

--- a/layers/layer9_python/.layerapi2_dependencies
+++ b/layers/layer9_python/.layerapi2_dependencies
@@ -1,0 +1,2 @@
+python@mfcom
+python{METWORK_PYTHON_MODE}@mfserv

--- a/layers/layer9_python/.layerapi2_label
+++ b/layers/layer9_python/.layerapi2_label
@@ -1,0 +1,1 @@
+python@mfserv

--- a/layers/layer9_python/Makefile
+++ b/layers/layer9_python/Makefile
@@ -1,0 +1,2 @@
+include ../../adm/root.mk
+include $(MFEXT_HOME)/share/layer.mk


### PR DESCRIPTION
(only minimal and full)
Associated with changes in mfext _metwork.spec, this reduces the number of layers installed by default when installing mfserv (only necessary mfext layers are installed)
Metapackage metwork-mfserv-minimal only installs the necessary layers for mfserv to work properly
Metapackage metwork-mfserv or metwork-mfserv-full installs all mfserv layers

linked to #26 (mfserv part)