### PR TITLE
feat: provide an easy way for a plugin to listen to an extra route

### DIFF
--- a/adm/Makefile
+++ b/adm/Makefile
@@ -1,4 +1,4 @@
-BINS=_make_circus_conf mfserv_conf_monitor.py _make_nginx_conf nginxfmt.py __make_nginx_conf
+BINS=_make_circus_conf mfserv_conf_monitor.py _make_nginx_conf nginxfmt.py __make_nginx_conf _plugins.is_dangerous
 
 include root.mk
 include $(MFEXT_HOME)/share/subdir_root.mk

--- a/adm/__make_nginx_conf
+++ b/adm/__make_nginx_conf
@@ -113,6 +113,14 @@ def get_conf(plugin_configuration_file):
             prefix_based_routing = \
                 parser.getboolean(section,
                                   "prefix_based_routing")
+        prefix_based_routing_extra_routes = []
+        if prefix_based_routing:
+            if parser.has_option(section, "prefix_based_routing_extra_routes"):
+                tmp = parser.get(section, "prefix_based_routing_extra_routes")
+                if tmp.strip() != "null":
+                    prefix_based_routing_extra_routes = \
+                        [x.strip() for x in tmp.strip().split(';')
+                         if x.startswith('/') and not x.endswith('/')]
         workdir = os.path.join(os.environ['MODULE_RUNTIME_HOME'], 'var',
                                'plugins', plugin_name, app)
         virtualdomains = set()
@@ -151,6 +159,10 @@ def get_conf(plugin_configuration_file):
         if app == "main" or len(apps) == 1:
             copy_conf = copy.deepcopy(app_conf)
             copy_conf['prefix'] = "/%s" % plugin_name
+            plugin_conf["apps"].append(copy_conf)
+        for extra_route in prefix_based_routing_extra_routes:
+            copy_conf = copy.deepcopy(app_conf)
+            copy_conf['prefix'] = extra_route
             plugin_conf["apps"].append(copy_conf)
     return plugin_conf
 

--- a/adm/_plugins.is_dangerous
+++ b/adm/_plugins.is_dangerous
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import os
+import sys
+from mfutil.plugins import get_plugin_info
+from configparser_extended import ExtendedConfigParser
+
+CONFIG = os.environ.get('MFCONFIG', 'GENERIC')
+
+infos = get_plugin_info(sys.argv[1])
+if not infos:
+    raise Exception("the plugin %s is not installed" % sys.argv[1])
+
+plugin_home = infos['home']
+config_ini = "%s/config.ini" % plugin_home
+parser = ExtendedConfigParser(config=CONFIG, strict=False,
+                              inheritance='im')
+parser.read(config_ini)
+dangerous = False
+if parser.has_option("general", "extra_nginx_conf_filename"):
+    tmp = parser.get("general", "extra_nginx_conf_filename").strip()
+    if tmp != "null":
+        print("WARNING: this plugin has a general extra nginx configuration")
+        dangerous = True
+app_sections = [x.strip() for x in parser.sections() if x.startswith("app_")]
+for app_section in app_sections:
+    if not parser.has_option(app_section, "prefix_based_routing_extra_routes"):
+        continue
+    tmp = parser.get(app_section, "prefix_based_routing_extra_routes").strip()
+    if tmp != "null":
+        print("WARNING: this plugin has a "
+              "prefix_based_routing_extra_routes == %s (!= null) "
+              "for the app: %s" % (tmp, app_section.replace("app_", "")))
+        dangerous = True
+if dangerous:
+    print("  => This is a dangerous plugin which can break the whole")
+    print("     mfserv module")
+    print("  => But it can be assumed if you trust the author")

--- a/adm/templates/plugins/default/{{cookiecutter.name}}/config.ini
+++ b/adm/templates/plugins/default/{{cookiecutter.name}}/config.ini
@@ -38,6 +38,8 @@ vendor={{cookiecutter.vendor}}
 # If you want to include some configuration fragments specific to an app
 # don't use this key (in [general] section] but the one in [app_xxxxx] section
 # Note: this key is not used with virtualdomain_based_routing
+# Note: if you use this key, you can break the whole mfserv module
+#       => so there will be a warning at plugin installation about that
 extra_nginx_conf_filename=null
 
 # If you need a redis instance for your plugin for basic needs (no persistence,
@@ -78,6 +80,15 @@ virtualdomain_based_routing=false
 # Route directly at the webserver part /static/ url path to static directory
 # inside the application directory
 static_routing=true
+
+# !!! ADVANCED SETTING !!!
+# Add extra routes to your plugin (starting by /, not ending by /, separated by ;)
+# Example: prefix_based_routing_extra_routes=/foo;/bar
+# null => no extra routes
+# Note: if you use this key, you can break the whole mfserv module
+#       and generate some conflicts with other plugins
+#       => so there will be a warning at plugin installation about that
+prefix_based_routing_extra_routes=null
 
 # !!! ADVANCED SETTING !!!
 # use this only if you are sure about what you are doing

--- a/adm/templates/plugins/django/{{cookiecutter.name}}/config.ini
+++ b/adm/templates/plugins/django/{{cookiecutter.name}}/config.ini
@@ -38,6 +38,8 @@ vendor={{cookiecutter.vendor}}
 # If you want to include some configuration fragments specific to an app
 # don't use this key (in [general] section] but the one in [app_xxxxx] section
 # Note: this key is not used with virtualdomain_based_routing
+# Note: if you use this key, you can break the whole mfserv module
+#       => so there will be a warning at plugin installation about that
 extra_nginx_conf_filename=null
 
 # If you need a redis instance for your plugin for basic needs (no persistence,
@@ -45,6 +47,7 @@ extra_nginx_conf_filename=null
 # To connect to your instance, use an unix socket connection to
 # the value of REDIS_SOCKET_UNIX_SOCKET_PATH env var.
 redis_service=0
+
 
 [app_{{cookiecutter.project_name}}]
 
@@ -75,6 +78,15 @@ virtualdomain_based_routing=false
 static_routing=true
 
 # !!! ADVANCED SETTING !!!
+# Add extra routes to your plugin (starting by /, not ending by /, separated by ;)
+# Example: prefix_based_routing_extra_routes=/foo;/bar
+# null => no extra routes
+# Note: if you use this key, you can break the whole mfserv module
+#       and generate some conflicts with other plugins
+#       => so there will be a warning at plugin installation about that
+prefix_based_routing_extra_routes=null
+
+# !!! ADVANCED SETTING !!!
 # use this only if you are sure about what you are doing
 # extra nginx configuration filename inside your plugin directory
 # null => no extra configuration
@@ -101,3 +113,13 @@ add_plugin_dir_to_python_path=true
 
 # If true, add app directory to python path
 add_app_dir_to_python_path=true
+
+
+# !!! ADVANCED SETTINGS !!!
+# You can add extra daemons which will be launched within your plugin
+# by providing configuration blocks [extra_daemon_*]
+# You have to provide a command to daemonize (the command must run in
+# foreground and not daemonize by itself)
+# [extra_daemon_foo]
+# cmd_and_args = /your/foreground/command command_arg1 command_arg2
+# numprocesses=1

--- a/adm/templates/plugins/empty/{{cookiecutter.name}}/config.ini
+++ b/adm/templates/plugins/empty/{{cookiecutter.name}}/config.ini
@@ -35,3 +35,12 @@ vendor={{cookiecutter.vendor}}
 # To connect to your instance, use an unix socket connection to
 # the value of REDIS_SOCKET_UNIX_SOCKET_PATH env var.
 redis_service=0
+
+# !!! ADVANCED SETTINGS !!!
+# You can add extra daemons which will be launched within your plugin
+# by providing configuration blocks [extra_daemon_*]
+# You have to provide a command to daemonize (the command must run in
+# foreground and not daemonize by itself)
+# [extra_daemon_foo]
+# cmd_and_args = /your/foreground/command command_arg1 command_arg2
+# numprocesses=1

--- a/adm/templates/plugins/node/{{cookiecutter.name}}/config.ini
+++ b/adm/templates/plugins/node/{{cookiecutter.name}}/config.ini
@@ -38,6 +38,8 @@ vendor={{cookiecutter.vendor}}
 # If you want to include some configuration fragments specific to an app
 # don't use this key (in [general] section] but the one in [app_xxxxx] section
 # Note: this key is not used with virtualdomain_based_routing
+# Note: if you use this key, you can break the whole mfserv module
+#       => so there will be a warning at plugin installation about that
 extra_nginx_conf_filename=null
 
 # If you need a redis instance for your plugin for basic needs (no persistence,
@@ -78,6 +80,15 @@ virtualdomain_based_routing=false
 static_routing=true
 
 # !!! ADVANCED SETTING !!!
+# Add extra routes to your plugin (starting by /, not ending by /, separated by ;)
+# Example: prefix_based_routing_extra_routes=/foo;/bar
+# null => no extra routes
+# Note: if you use this key, you can break the whole mfserv module
+#       and generate some conflicts with other plugins
+#       => so there will be a warning at plugin installation about that
+prefix_based_routing_extra_routes=null
+
+# !!! ADVANCED SETTING !!!
 # use this only if you are sure about what you are doing
 # extra nginx configuration filename inside your plugin directory
 # null => no extra configuration
@@ -104,3 +115,13 @@ add_plugin_dir_to_node_path=true
 
 # If true, add app directory to node path
 add_app_dir_to_node_path=false
+
+
+# !!! ADVANCED SETTINGS !!!
+# You can add extra daemons which will be launched within your plugin
+# by providing configuration blocks [extra_daemon_*]
+# You have to provide a command to daemonize (the command must run in
+# foreground and not daemonize by itself)
+# [extra_daemon_foo]
+# cmd_and_args = /your/foreground/command command_arg1 command_arg2
+# numprocesses=1

--- a/adm/templates/plugins/static/{{cookiecutter.name}}/config.ini
+++ b/adm/templates/plugins/static/{{cookiecutter.name}}/config.ini
@@ -38,6 +38,8 @@ vendor={{cookiecutter.vendor}}
 # If you want to include some configuration fragments specific to an app
 # don't use this key (in [general] section] but the one in [app_xxxxx] section
 # Note: this key is not used with virtualdomain_based_routing
+# Note: if you use this key, you can break the whole mfserv module
+#       => so there will be a warning at plugin installation about that
 extra_nginx_conf_filename=null
 
 
@@ -58,6 +60,15 @@ prefix_based_routing=true
 # http://{plugin_name}.{host}:{port}/... if app_name == main or only one app in the plugin
 # NOTE: you need a DNS "catch all" to do that (like a DNS CNAME *.{host} => {ip_of_the_host}
 virtualdomain_based_routing=false
+
+# !!! ADVANCED SETTING !!!
+# Add extra routes to your plugin (starting by /, not ending by /, separated by ;)
+# Example: prefix_based_routing_extra_routes=/foo;/bar
+# null => no extra routes
+# Note: if you use this key, you can break the whole mfserv module
+#       and generate some conflicts with other plugins
+#       => so there will be a warning at plugin installation about that
+prefix_based_routing_extra_routes=null
 
 # !!! ADVANCED SETTING !!!
 # use this only if you are sure about what you are doing


### PR DESCRIPTION
Close #111 

Missing:

- [x] add a warning during plugins.install