### PR TITLE
feat: remove "name" from the list of questions during plugin bootstrap

### DIFF
--- a/adm/templates/plugins/default/cookiecutter.json
+++ b/adm/templates/plugins/default/cookiecutter.json
@@ -1,5 +1,4 @@
 {
-    "name": "name_of_your_plugin",
     "version": "0.0.1",
     "one_line_summary": "one line summary",
     "crontab_support": ["no", "yes"],

--- a/adm/templates/plugins/django/cookiecutter.json
+++ b/adm/templates/plugins/django/cookiecutter.json
@@ -1,5 +1,4 @@
 {
-    "name": "name_of_your_plugin",
     "version": "0.0.1",
     "one_line_summary": "one line summary",
     "crontab_support": ["no", "yes"],

--- a/adm/templates/plugins/empty/cookiecutter.json
+++ b/adm/templates/plugins/empty/cookiecutter.json
@@ -1,5 +1,4 @@
 {
-    "name": "name_of_your_plugin",
     "version": "0.0.1",
     "one_line_summary": "one line summary",
     "crontab_support": ["no", "yes"],

--- a/adm/templates/plugins/node/cookiecutter.json
+++ b/adm/templates/plugins/node/cookiecutter.json
@@ -1,5 +1,4 @@
 {
-    "name": "name_of_your_plugin",
     "version": "0.0.1",
     "one_line_summary": "A nodejs cluster express application",
     "crontab_support": ["no", "yes"],

--- a/adm/templates/plugins/static/cookiecutter.json
+++ b/adm/templates/plugins/static/cookiecutter.json
@@ -1,5 +1,4 @@
 {
-    "name": "name_of_your_plugin",
     "version": "0.0.1",
     "one_line_summary": "one line summary",
     "license": ["Proprietary", "BSD", "MIT", "GPL", "Specific"],


### PR DESCRIPTION
The name is already given on the CLI.

See metwork-framework/mfcom#111