### PR TITLE
build: remove useless line (I think), because [app_main] is defined in

### DIFF
--- a/adm/templates/plugins/static/{{cookiecutter.name}}/config.ini
+++ b/adm/templates/plugins/static/{{cookiecutter.name}}/config.ini
@@ -7,9 +7,6 @@
 
 {% endblock %}
 
-
-[app_main]
-
 {% block app_workers %}
 
 {% endblock %}


### PR DESCRIPTION
template _common