### PR TITLE
feat: add a new configuration key (for extending nginx conf)

### DIFF
--- a/adm/__make_nginx_conf
+++ b/adm/__make_nginx_conf
@@ -55,6 +55,21 @@ ALL_TYP_LIST = \
 LOGGER = get_logger("__make_nginx_conf")
 
 
+def get_nginx_conf_string(parser, plugin_directory, plugin_name, section, key):
+    extra_nginx_conf_string = ""
+    if parser.has_option(section, key):
+        extra_nginx_conf_filename = parser.get(section, key)
+        if extra_nginx_conf_filename != "null":
+            extra_nginx_conf_filepath = \
+                os.path.join(plugin_directory,
+                             extra_nginx_conf_filename)
+            with open(extra_nginx_conf_filepath, "r") as f:
+                extra_nginx_conf_string = f.read()
+    return envtpl.render_string(
+        extra_nginx_conf_string,
+        extra_variables={"PLUGIN": {"name": plugin_name}})
+
+
 def get_conf(plugin_configuration_file):
     plugin_conf = {}
     parser = ExtendedConfigParser(config=CONFIG, strict=False,
@@ -68,22 +83,23 @@ def get_conf(plugin_configuration_file):
     apps = [x.replace("app_", "", 1).split(':')[0] for x in parser.sections()
             if x.startswith("app_")]
 
-    extra_general_nginx_conf_string = ""
-    if parser.has_option("general", "extra_nginx_conf_filename"):
-        extra_general_nginx_conf_filename = \
-            parser.get("general", "extra_nginx_conf_filename")
-        if extra_general_nginx_conf_filename != "null":
-            extra_general_nginx_conf_filepath = \
-                os.path.join(plugin_directory,
-                             extra_general_nginx_conf_filename)
-            with open(extra_general_nginx_conf_filepath, "r") as f:
-                extra_general_nginx_conf_string = f.read()
+    extra_general_nginx_http_conf_string = \
+        get_nginx_conf_string(parser, plugin_directory, plugin_name, "general",
+                              "extra_nginx_http_conf_filename")
+    if extra_general_nginx_http_conf_string == "":
+        # DEPRECATED (for compatibility)
+        extra_general_nginx_http_conf_string = \
+            get_nginx_conf_string(parser, plugin_directory, plugin_name,
+                                  "general", "extra_nginx_conf_filename")
+    extra_general_nginx_server_conf_string = \
+        get_nginx_conf_string(parser, plugin_directory, plugin_name, "general",
+                              "extra_nginx_server_conf_filename")
 
     plugin_conf["name"] = plugin_name
-    plugin_conf["extra_general_nginx_conf_string"] = \
-        envtpl.render_string(extra_general_nginx_conf_string,
-                             extra_variables={"PLUGIN": plugin_conf})
-
+    plugin_conf["extra_general_nginx_http_conf_string"] = \
+        extra_general_nginx_http_conf_string
+    plugin_conf["extra_general_nginx_server_conf_string"] = \
+        extra_general_nginx_server_conf_string
     plugin_conf['lua_package_paths'] = []
     plugin_conf["apps"] = []
 
@@ -96,26 +112,12 @@ def get_conf(plugin_configuration_file):
         if len(glob.glob(os.path.join(plugin_directory, app, '*.lua'))) > 0:
             lua_package_path = os.path.join(plugin_directory, app, '?.lua')
             plugin_conf['lua_package_paths'].append(lua_package_path)
-        extra_nginx_conf_string = ""
-        if parser.has_option(section, "extra_nginx_conf_filename"):
-            extra_nginx_conf_filename = parser.get(section,
-                                                   "extra_nginx_conf_filename")
-            if extra_nginx_conf_filename != "null":
-                extra_nginx_conf_filepath = \
-                    os.path.join(plugin_directory,
-                                 extra_nginx_conf_filename)
-                with open(extra_nginx_conf_filepath, "r") as f:
-                    extra_nginx_conf_string = f.read()
-        extra_nginx_conf_static_string = ""
-        if parser.has_option(section, "extra_nginx_conf_static_filename"):
-            extra_nginx_conf_static_filename = \
-                parser.get(section, "extra_nginx_conf_static_filename")
-            if extra_nginx_conf_static_filename != "null":
-                extra_nginx_conf_static_filepath = \
-                    os.path.join(plugin_directory,
-                                 extra_nginx_conf_static_filename)
-                with open(extra_nginx_conf_static_filepath, "r") as f:
-                    extra_nginx_conf_static_string = f.read()
+        extra_nginx_conf_string = \
+            get_nginx_conf_string(parser, plugin_directory, plugin_name,
+                                  section, "extra_nginx_conf_filename")
+        extra_nginx_conf_static_string = \
+            get_nginx_conf_string(parser, plugin_directory, plugin_name,
+                                  section, "extra_nginx_conf_static_filename")
         static_routing = True
         if parser.has_option(section, "static_routing"):
             static_routing = parser.getboolean(section, "static_routing")

--- a/adm/templates/plugins/_common/config.ini
+++ b/adm/templates/plugins/_common/config.ini
@@ -38,11 +38,30 @@ vendor={{cookiecutter.vendor}}
 # null => no extra configuration
 # The content will be included directly in "http" section
 # If you want to include some configuration fragments specific to an app
-# don't use this key (in [general] section] but the one in [app_xxxxx] section
+# don't use this key (in [general] section] but extra_nginx_conf_filename
+# in [app_xxxxx] section.
+# Note: if you use this key, you can break the whole mfserv module
+#       => so there will be a warning at plugin installation about that
+# Note: the different between this key and the one just bellow is that
+#       the configuration fragment will be inserted in "http" section
+#       (for this one) and in "server" section (for the one above)
+extra_nginx_http_conf_filename=null
+
+# !!! ADVANCED SETTING !!!
+# Use this only if you are sure about what you are doing
+# extra nginx configuration filename inside your plugin directory
+# null => no extra configuration
+# The content will be included directly in "server" section
+# If you want to include some configuration fragments specific to an app
+# don't use this key (in [general] section] but extra_nginx_conf_filename
+# in [app_xxxxx] section.
 # Note: this key is not used with virtualdomain_based_routing
 # Note: if you use this key, you can break the whole mfserv module
 #       => so there will be a warning at plugin installation about that
-extra_nginx_conf_filename=null
+# Note: the different between this key and the one just above is that
+#       the configuration fragment will be inserted in "server" section
+#       (for this one) and in "http" section (for the one above)
+extra_nginx_server_conf_filename=null
 
 {% endblock -%}
 
@@ -180,7 +199,7 @@ prefix_based_routing_extra_routes=null
 # null => no extra configuration
 # the content will be included directly in your app "location" section
 # if you want to include some configuration fragments at a more general level
-# don't use this key but the one in [general] section)
+# don't use this key but those in the [general] section
 # Note: if you use virtualdomain_based_routing, the content will be included
 # in the custom "server" section (specific to your app and not in "location")
 extra_nginx_conf_filename=null

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -93,10 +93,10 @@ http {
     {% endfor %}
 
     {% for PLUGIN in PLUGINS %}
-        {% if PLUGIN.extra_general_nginx_conf_string %}
-            ##### BEGIN OF GENERAL EXTRA NGINX CONF FOR PLUGIN {{PLUGIN.name}} #####
-            {{PLUGIN.extra_general_nginx_conf_string}}
-            ##### END OF GENERAL EXTRA NGINX CONF FOR PLUGIN {{PLUGIN.name}} #####
+        {% if PLUGIN.extra_general_nginx_http_conf_string %}
+            ##### BEGIN OF GENERAL EXTRA (HTTP) NGINX CONF FOR PLUGIN {{PLUGIN.name}} #####
+            {{PLUGIN.extra_general_nginx_http_conf_string}}
+            ##### END OF GENERAL EXTRA (HTTP) NGINX CONF FOR PLUGIN {{PLUGIN.name}} #####
         {% endif %}
     {% endfor %}
 
@@ -108,6 +108,14 @@ http {
         listen {{MFSERV_NGINX_PORT}} backlog=40000 default_server;
         {% endif %}
         server_name 127.0.0.1;
+
+        {% for PLUGIN in PLUGINS %}
+            {% if PLUGIN.extra_general_nginx_server_conf_string %}
+                ##### BEGIN OF GENERAL EXTRA (SERVER) NGINX CONF FOR PLUGIN {{PLUGIN.name}} #####
+                {{PLUGIN.extra_general_nginx_server_conf_string}}
+                ##### END OF GENERAL EXTRA (SERVER) NGINX CONF FOR PLUGIN {{PLUGIN.name}} #####
+            {% endif %}
+        {% endfor %}
 
         # Status page for metrics (FIXME: rename this in __status)
         location = /status {


### PR DESCRIPTION
An existing configuration key is also renamed but with backward
compatibility.

(cherry picked from commit 884dfd88ddd4eaaadb77960a22aaacca0e469862)

# Conflicts:
#	adm/__make_nginx_conf