### PR TITLE
feat: replace MODULE* environment variables names by MFMODULE* (MODUL…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-MODULE=MFSERV
-MODULE_LOWERCASE=mfserv
+MFMODULE=MFSERV
+MFMODULE_LOWERCASE=mfserv
 
 -include adm/root.mk
 -include $(MFEXT_HOME)/share/main_root.mk

--- a/adm/__make_nginx_conf
+++ b/adm/__make_nginx_conf
@@ -10,16 +10,16 @@ from configparser_extended import ExtendedConfigParser
 from mflog import get_logger
 from mfutil.plugins import layerapi2_label_to_plugin_name
 
-MODULE_RUNTIME_HOME = os.environ["MODULE_RUNTIME_HOME"]
-MFSERV_PLUGINS_HOME = os.path.join(MODULE_RUNTIME_HOME,
+MFMODULE_RUNTIME_HOME = os.environ["MFMODULE_RUNTIME_HOME"]
+MFSERV_PLUGINS_HOME = os.path.join(MFMODULE_RUNTIME_HOME,
                                    "var", "plugins")
-MFSERV_PLUGINS_HOTSWAP_HOME = os.path.join(MODULE_RUNTIME_HOME,
+MFSERV_PLUGINS_HOTSWAP_HOME = os.path.join(MFMODULE_RUNTIME_HOME,
                                            "tmp", "plugins.hotswap")
 MFSERV_NGINX_TIMEOUT = int(os.environ['MFSERV_NGINX_TIMEOUT'])
 CONFIG = os.environ.get('MFCONFIG', 'GENERIC')
 HOSTNAME = os.environ.get('MFCOM_HOSTNAME')
 HOSTNAME_FULL = os.environ.get('MFCOM_HOSTNAME_FULL')
-MODULE = os.environ['MODULE']
+MFMODULE = os.environ['MFMODULE']
 
 '''
 Below are defined process types depending on the code language
@@ -216,21 +216,21 @@ def get_conf(plugin_configuration_file, hot_swap_plugin=False):
                     "timeout": timeout + 2,  # kill the backend first
                     "static_routing": static_routing,
                     "sockets": ["%s/var/default_%s.socket" %
-                                (MODULE_RUNTIME_HOME, name)],
+                                (MFMODULE_RUNTIME_HOME, name)],
                     "type": typ}
         if typ in GUNICORN_TYP_LIST:
             app_conf["sockets"] = ["%s/var/gunicorn_%s%s.socket" %
-                                   (MODULE_RUNTIME_HOME,
+                                   (MFMODULE_RUNTIME_HOME,
                                     hot_swap_prefix, name)]
         elif typ not in GUNICORN_TYP_LIST:
             if typ == "node":
                 sockets = ["%s/var/%s_%s%s_%i.socket" %
-                           (MODULE_RUNTIME_HOME, typ, hot_swap_prefix,
+                           (MFMODULE_RUNTIME_HOME, typ, hot_swap_prefix,
                             plugin_name, i + 1)
                            for i in range(0, workers)]
             else:
                 sockets = ["%s/var/%s_%s%s_%s_%i.socket" %
-                           (MODULE_RUNTIME_HOME, typ, hot_swap_prefix,
+                           (MFMODULE_RUNTIME_HOME, typ, hot_swap_prefix,
                             plugin_name, app, i + 1)
                            for i in range(0, workers)]
             app_conf["sockets"] = sockets
@@ -280,16 +280,16 @@ lua_package_paths = \
                          "%s/config/?.lua" % os.environ['MFCOM_HOME'],
                          "%s/lib/?.lua" % os.environ['MFCOM_HOME']]
 
-nginx_conf_file = os.path.join(os.environ['MODULE_HOME'], 'config',
+nginx_conf_file = os.path.join(os.environ['MFMODULE_HOME'], 'config',
                                'nginx.conf')
 
 with open(nginx_conf_file, "r") as f:
     extra_variables = {
         "PLUGINS": plugins,
         "LUA_PACKAGE_PATH": ";".join(lua_package_paths) + ";;",
-        "MODULE_ENVIRONMENT": sorted([x for x in os.environ.keys()
-                                      if x.startswith(MODULE + "_") or
-                                      x.startswith("MODULE_")])
+        "MFMODULE_ENVIRONMENT": sorted([x for x in os.environ.keys()
+                                      if x.startswith(MFMODULE + "_") or
+                                      x.startswith("MFMODULE_")])
     }
     content = envtpl.render_string(f.read(), extra_variables=extra_variables,
                                    keep_multi_blank_lines=False)

--- a/adm/_check_circus_conf
+++ b/adm/_check_circus_conf
@@ -11,7 +11,7 @@ else
     for TMP in $(plugins.list --raw 2>/dev/null); do
         PLUGIN=$(echo "${TMP}" |awk -F '~~~' '{print $1;}')
         PHOME=$(echo "${TMP}" |awk -F '~~~' '{print $4;}')
-        TMPOUTPUT="${MODULE_RUNTIME_HOME}/tmp/confdebug.$(get_unique_hexa_identifier)"
+        TMPOUTPUT="${MFMODULE_RUNTIME_HOME}/tmp/confdebug.$(get_unique_hexa_identifier)"
         _make_circus_conf "${PHOME}" >"${TMPOUTPUT}" 2>&1
         if test $? -ne 0; then
             echo_bold "=> the plugin ${PLUGIN} seems to break circus conf"

--- a/adm/_check_nginx_conf
+++ b/adm/_check_nginx_conf
@@ -11,7 +11,7 @@ else
     for TMP in $(plugins.list --raw 2>/dev/null); do
         PLUGIN=$(echo "${TMP}" |awk -F '~~~' '{print $1;}')
         PHOME=$(echo "${TMP}" |awk -F '~~~' '{print $4;}')
-        TMPOUTPUT="${MODULE_RUNTIME_HOME}/tmp/confdebug.$(get_unique_hexa_identifier)"
+        TMPOUTPUT="${MFMODULE_RUNTIME_HOME}/tmp/confdebug.$(get_unique_hexa_identifier)"
         _make_nginx_conf "${PHOME}" >"${TMPOUTPUT}" 2>&1
         if test $? -ne 0; then
             echo_bold "=> the plugin ${PLUGIN} seems to break nginx conf"

--- a/adm/_make_circus_conf
+++ b/adm/_make_circus_conf
@@ -8,14 +8,14 @@ from configparser_extended import ExtendedConfigParser
 from mflog import get_logger
 from mfutil.plugins import layerapi2_label_to_plugin_name
 
-MFSERV_PLUGINS_HOME = os.path.join(os.environ["MODULE_RUNTIME_HOME"],
+MFSERV_PLUGINS_HOME = os.path.join(os.environ["MFMODULE_RUNTIME_HOME"],
                                    "var", "plugins")
-MFSERV_PLUGINS_HOTSWAP_HOME = os.path.join(os.environ["MODULE_RUNTIME_HOME"],
+MFSERV_PLUGINS_HOTSWAP_HOME = os.path.join(os.environ["MFMODULE_RUNTIME_HOME"],
                                            "tmp", "plugins.hotswap")
 LOG_LEVEL = os.environ.get('MFSERV_LOG_MINIMAL_LEVEL', 'INFO')
 CONFIG = os.environ.get('MFCONFIG', 'GENERIC')
-MODULE_RUNTIME_HOME = os.environ["MODULE_RUNTIME_HOME"]
-MODULE_HOME = os.environ["MODULE_HOME"]
+MFMODULE_RUNTIME_HOME = os.environ["MFMODULE_RUNTIME_HOME"]
+MFMODULE_HOME = os.environ["MFMODULE_HOME"]
 MFSERV_NGINX_TIMEOUT = int(os.environ['MFSERV_NGINX_TIMEOUT'])
 
 '''
@@ -88,18 +88,18 @@ def get_std_redirect_args(prefix, plugin_name, app=None,
         if app:
             std_prefix = \
                 "%s/log/%s_%s_%s_worker$(circus.wid)" % \
-                (MODULE_RUNTIME_HOME, prefix, plugin_name, app)
+                (MFMODULE_RUNTIME_HOME, prefix, plugin_name, app)
         else:
             std_prefix = \
                 "%s/log/%s_%s_worker$(circus.wid)" % \
-                (MODULE_RUNTIME_HOME, prefix, plugin_name)
+                (MFMODULE_RUNTIME_HOME, prefix, plugin_name)
     else:
         if app:
             std_prefix = "%s/log/%s_%s_%s" % \
-                (MODULE_RUNTIME_HOME, prefix, plugin_name, app)
+                (MFMODULE_RUNTIME_HOME, prefix, plugin_name, app)
         else:
             std_prefix = "%s/log/%s_%s" % \
-                (MODULE_RUNTIME_HOME, prefix, plugin_name)
+                (MFMODULE_RUNTIME_HOME, prefix, plugin_name)
     if split_stdout_sterr:
         return "-o %s.stdout -e %s.stderr" % (std_prefix, std_prefix)
     else:
@@ -231,7 +231,7 @@ def get_conf(plugin_configuration_file, hot_swap_plugin=False):
 
         if typ in GUNICORN_TYP_LIST:
             bind = "unix:%s/var/gunicorn_app_%s_%s.socket" % (
-                MODULE_RUNTIME_HOME, plugin_name, app)
+                MFMODULE_RUNTIME_HOME, plugin_name, app)
             if typ == "gunicorn3_asyncio":
                 worker_class = "aiohttp.worker.GunicornWebWorker"
             else:
@@ -253,7 +253,7 @@ def get_conf(plugin_configuration_file, hot_swap_plugin=False):
 
         elif typ == "aiohttp":
             bind = "%s/var/aiohttp_%s_%s_$(circus.wid).socket" % (
-                MODULE_RUNTIME_HOME, plugin_name, app)
+                MFMODULE_RUNTIME_HOME, plugin_name, app)
             layer_wrapper_extra_args = get_layer_wrapper_extra_args(
                 original_plugin_name, plugin_dir, app,
                 apdtpp=add_plugin_dir_to_python_path,
@@ -265,7 +265,7 @@ def get_conf(plugin_configuration_file, hot_swap_plugin=False):
 
         elif typ in ("python3_sync", "python2_sync"):
             bind = "%s/var/%s_%s_%s_$(circus.wid).socket" % (
-                MODULE_RUNTIME_HOME, typ, plugin_name, app)
+                MFMODULE_RUNTIME_HOME, typ, plugin_name, app)
             layer_wrapper_extra_args = get_layer_wrapper_extra_args(
                 original_plugin_name, plugin_dir, app,
                 apdtpp=add_plugin_dir_to_python_path,
@@ -280,7 +280,7 @@ def get_conf(plugin_configuration_file, hot_swap_plugin=False):
 
         elif typ in JS_TYP_LIST:
             bind = "%s/var/node_%s_$(circus.wid).socket" % (
-                MODULE_RUNTIME_HOME, plugin_name)
+                MFMODULE_RUNTIME_HOME, plugin_name)
             layer_wrapper_extra_args = get_layer_wrapper_extra_args(
                 original_plugin_name, plugin_dir)
             node_server = "%s/%s/%s" % (plugin_dir, app, main_arg)
@@ -338,7 +338,7 @@ def get_conf(plugin_configuration_file, hot_swap_plugin=False):
         extra_conf["cmd_args"] = "%s -- plugin_wrapper %s -- %s" % (
             std_redirect_extra_args, original_plugin_name,
             "redis-server %s/tmp/config_auto/redis_plugin_%s.conf" % (
-                MODULE_RUNTIME_HOME, original_plugin_name))
+                MFMODULE_RUNTIME_HOME, original_plugin_name))
         extra_conf["numprocesses"] = 1
         extra_conf["max_age"] = 0
         extra_conf["graceful_timeout"] = 10
@@ -346,8 +346,8 @@ def get_conf(plugin_configuration_file, hot_swap_plugin=False):
         extra_conf["debug"] = False
         plugin_conf["extra_daemons"].append(extra_conf)
         with open("%s/tmp/config_auto/redis_plugin_%s.conf" %
-                  (MODULE_RUNTIME_HOME, plugin_name), "w+") as f:
-            with open("%s/config/redis_plugin_xxx.conf" % MODULE_HOME,
+                  (MFMODULE_RUNTIME_HOME, plugin_name), "w+") as f:
+            with open("%s/config/redis_plugin_xxx.conf" % MFMODULE_HOME,
                       "r") as f2:
                 content = f2.read()
             new_content = envtpl.render_string(content,
@@ -358,7 +358,7 @@ def get_conf(plugin_configuration_file, hot_swap_plugin=False):
     return plugin_conf
 
 
-circus_ini_file = os.path.join(os.environ['MODULE_HOME'], 'config',
+circus_ini_file = os.path.join(os.environ['MFMODULE_HOME'], 'config',
                                'circus.ini')
 plugins = []
 if len(sys.argv) == 2:

--- a/adm/_make_nginx_conf
+++ b/adm/_make_nginx_conf
@@ -2,12 +2,12 @@
 
 set -eu
 
-TMPFILE="${MODULE_RUNTIME_HOME}/tmp/nginx_conf.$$"
-TMPFILE2="${MODULE_RUNTIME_HOME}/tmp/nginx_conf2.$$"
-TMPFILE3="${MODULE_RUNTIME_HOME}/tmp/nginx_conf3.$$"
+TMPFILE="${MFMODULE_RUNTIME_HOME}/tmp/nginx_conf.$$"
+TMPFILE2="${MFMODULE_RUNTIME_HOME}/tmp/nginx_conf2.$$"
+TMPFILE3="${MFMODULE_RUNTIME_HOME}/tmp/nginx_conf3.$$"
 
-if test -f "${MODULE_RUNTIME_HOME}/var/uuid"; then
-    UUID=$(cat "${MODULE_RUNTIME_HOME}/var/uuid")
+if test -f "${MFMODULE_RUNTIME_HOME}/var/uuid"; then
+    UUID=$(cat "${MFMODULE_RUNTIME_HOME}/var/uuid")
     if test "${UUID}" = ""; then
         UUID="unknown"
     fi
@@ -22,8 +22,8 @@ nginxfmt.py "${TMPFILE}"
 cat -s "${TMPFILE}" |sed 's/~~~1/{/g' |sed 's/~~~2/}/g' |grep -v 'FIXME: ugly hack' >"${TMPFILE2}"
 rm -f "${TMPFILE}"
 
-if ! test -f "${MODULE_RUNTIME_HOME}/tmp/config_auto/mime.types"; then
-    cp -f "${MFEXT_HOME}/opt/openresty/config/mime.types" "${MODULE_RUNTIME_HOME}/tmp/config_auto/mime.types"
+if ! test -f "${MFMODULE_RUNTIME_HOME}/tmp/config_auto/mime.types"; then
+    cp -f "${MFEXT_HOME}/opt/openresty/config/mime.types" "${MFMODULE_RUNTIME_HOME}/tmp/config_auto/mime.types"
 fi
 set +e
 "${MFEXT_HOME}/opt/openresty/nginx/sbin/nginx" -t -c "${TMPFILE2}" >"${TMPFILE3}" 2>&1

--- a/adm/bjoern_wrapper.py
+++ b/adm/bjoern_wrapper.py
@@ -18,8 +18,8 @@ import mfutil
 
 LOGGER = mflog.get_logger("bjoern_wrapper")
 MFSERV_NGINX_PORT = int(os.environ['MFSERV_NGINX_PORT'])
-MODULE = os.environ['MODULE']
-CURRENT_PLUGIN_NAME_ENV_VAR = "%s_CURRENT_PLUGIN_NAME" % MODULE
+MFMODULE = os.environ['MFMODULE']
+CURRENT_PLUGIN_NAME_ENV_VAR = "%s_CURRENT_PLUGIN_NAME" % MFMODULE
 if CURRENT_PLUGIN_NAME_ENV_VAR in os.environ:
     PLUGIN = os.environ[CURRENT_PLUGIN_NAME_ENV_VAR]
 else:

--- a/adm/mfserv_conf_monitor.py
+++ b/adm/mfserv_conf_monitor.py
@@ -7,19 +7,19 @@ from mfutil import BashWrapper, BashWrapperOrRaise
 from conf_monitor import ConfMonitorRunner, md5sumfile
 
 LOGGER = getLogger("conf_monitor")
-MODULE_RUNTIME_HOME = os.environ['MODULE_RUNTIME_HOME']
+MFMODULE_RUNTIME_HOME = os.environ['MFMODULE_RUNTIME_HOME']
 NGINX_FLAG = (int(os.environ['MFSERV_NGINX_FLAG']) == 1)
 
 
 def make_new_nginx_conf():
-    new_nginx_conf = "%s/tmp/tmp_nginx_conf2" % MODULE_RUNTIME_HOME
+    new_nginx_conf = "%s/tmp/tmp_nginx_conf2" % MFMODULE_RUNTIME_HOME
     cmd = "_make_nginx_conf >%s" % new_nginx_conf
     BashWrapperOrRaise(cmd)
     return (new_nginx_conf, md5sumfile(new_nginx_conf))
 
 
 def get_old_nginx_conf():
-    old_nginx_conf = "%s/tmp/config_auto/nginx.conf" % MODULE_RUNTIME_HOME
+    old_nginx_conf = "%s/tmp/config_auto/nginx.conf" % MFMODULE_RUNTIME_HOME
     return (old_nginx_conf, md5sumfile(old_nginx_conf))
 
 

--- a/adm/mfxxx.start.custom
+++ b/adm/mfxxx.start.custom
@@ -1,9 +1,9 @@
 {% extends "mfxxx.start" %}
 
 {% block custom_before_circus %}
-    if test -d "${MODULE_RUNTIME_HOME}/tmp/plugins.hotswap"; then
-        echo_bold "WARNING: ${MODULE_RUNTIME_HOME}/tmp/plugins.hotswap found => let's delete it"
-        rm -Rf "${MODULE_RUNTIME_HOME}/tmp/plugins.hotswap"
+    if test -d "${MFMODULE_RUNTIME_HOME}/tmp/plugins.hotswap"; then
+        echo_bold "WARNING: ${MFMODULE_RUNTIME_HOME}/tmp/plugins.hotswap found => let's delete it"
+        rm -Rf "${MFMODULE_RUNTIME_HOME}/tmp/plugins.hotswap"
     fi
     _check_circus_conf || RES=1
 {% endblock %}

--- a/adm/plugins.hotswap
+++ b/adm/plugins.hotswap
@@ -11,9 +11,9 @@ from mfutil.plugins import get_plugin_info, init_plugins_base, \
     install_plugin, uninstall_plugin
 
 CIRCUS_ENDPOINT = os.environ['MFSERV_CIRCUS_ENDPOINT']
-MODULE_RUNTIME_HOME = os.environ['MODULE_RUNTIME_HOME']
+MFMODULE_RUNTIME_HOME = os.environ['MFMODULE_RUNTIME_HOME']
 DESCRIPTION = "hotswap the current installed plugin with a newer version"
-HOTSWAP_PLUGINS_BASE = "%s/tmp/plugins.hotswap" % MODULE_RUNTIME_HOME
+HOTSWAP_PLUGINS_BASE = "%s/tmp/plugins.hotswap" % MFMODULE_RUNTIME_HOME
 
 
 def init_hotswap_plugins_base():
@@ -119,20 +119,20 @@ def wait(sleep):
 
 def block_autorestart():
     echo_running("Blocking mfserv.autorestart...")
-    BashWrapper("touch %s/var/block_autorestart" % MODULE_RUNTIME_HOME)
+    BashWrapper("touch %s/var/block_autorestart" % MFMODULE_RUNTIME_HOME)
     echo_ok()
 
 
 def unblock_autorestart():
     echo_running("Unblocking mfserv.autorestart...")
-    BashWrapper("rm -f %s/var/block_autorestart" % MODULE_RUNTIME_HOME)
+    BashWrapper("rm -f %s/var/block_autorestart" % MFMODULE_RUNTIME_HOME)
     echo_ok()
 
 
 def circus_reload():
     echo_running("Generating new circus conf...")
     x = BashWrapper("_make_circus_conf >%s/tmp/config_auto/circus.ini" %
-                    MODULE_RUNTIME_HOME)
+                    MFMODULE_RUNTIME_HOME)
     _bash_wrapper_to_diagnostic(x)
     echo_running("Reloading circus...")
     x = BashWrapper("_circus.reload")
@@ -142,7 +142,7 @@ def circus_reload():
 def nginx_reload():
     echo_running("Generating new nginx conf...")
     x = BashWrapper("_make_nginx_conf >%s/tmp/config_auto/nginx.conf" %
-                    MODULE_RUNTIME_HOME)
+                    MFMODULE_RUNTIME_HOME)
     _bash_wrapper_to_diagnostic(x)
     echo_running("Reloading nginx...")
     x = BashWrapper("_nginx.reload")

--- a/adm/profile.custom
+++ b/adm/profile.custom
@@ -1,4 +1,4 @@
 {% extends "profile" %}
 {% block custom %}
-field_prepend METWORK_LAYERS_PATH {{MODULE_HOME}}/var/plugins
+field_prepend METWORK_LAYERS_PATH {{MFMODULE_HOME}}/var/plugins
 {% endblock %}

--- a/adm/templates/plugins/_common/config.ini
+++ b/adm/templates/plugins/_common/config.ini
@@ -12,7 +12,7 @@
 # - the old "name" key in this file is not used anymore
 
 # Version of the plugin (X.Y.Z)
-# If the value is {% raw %}{{MODULE_VERSION}}{% endraw %},
+# If the value is {% raw %}{{MFMODULE_VERSION}}{% endraw %},
 # the current module version is used
 version={{cookiecutter.version}}
 

--- a/adm/templates/plugins/_common/crontab
+++ b/adm/templates/plugins/_common/crontab
@@ -1,3 +1,3 @@
 # Your crontab fragment here
 # Example:
-# 0 2 * * * {% raw %}{{MFSERV_HOME}}{% endraw %}/bin/cronwrap.sh -l -e -- plugin_wrapper {{cookiecutter.name}} your_command.sh >>{% raw %}{{MODULE_RUNTIME_HOME}}{% endraw %}/log/your_command.log 2>&1
+# 0 2 * * * {% raw %}{{MFSERV_HOME}}{% endraw %}/bin/cronwrap.sh -l -e -- plugin_wrapper {{cookiecutter.name}} your_command.sh >>{% raw %}{{MFMODULE_RUNTIME_HOME}}{% endraw %}/log/your_command.log 2>&1

--- a/adm/templates/plugins/default/{{cookiecutter.name}}/.layerapi2_extra_env
+++ b/adm/templates/plugins/default/{{cookiecutter.name}}/.layerapi2_extra_env
@@ -1,1 +1,1 @@
-REDIS_SOCKET_UNIX_SOCKET_PATH={MODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket
+REDIS_SOCKET_UNIX_SOCKET_PATH={MFMODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket

--- a/adm/templates/plugins/django/{{cookiecutter.name}}/.layerapi2_extra_env
+++ b/adm/templates/plugins/django/{{cookiecutter.name}}/.layerapi2_extra_env
@@ -1,1 +1,1 @@
-REDIS_SOCKET_UNIX_SOCKET_PATH={MODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket
+REDIS_SOCKET_UNIX_SOCKET_PATH={MFMODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket

--- a/adm/templates/plugins/empty/{{cookiecutter.name}}/.layerapi2_extra_env
+++ b/adm/templates/plugins/empty/{{cookiecutter.name}}/.layerapi2_extra_env
@@ -1,1 +1,1 @@
-REDIS_SOCKET_UNIX_SOCKET_PATH={MODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket
+REDIS_SOCKET_UNIX_SOCKET_PATH={MFMODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket

--- a/adm/templates/plugins/flask/{{cookiecutter.name}}/.layerapi2_extra_env
+++ b/adm/templates/plugins/flask/{{cookiecutter.name}}/.layerapi2_extra_env
@@ -1,1 +1,1 @@
-REDIS_SOCKET_UNIX_SOCKET_PATH={MODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket
+REDIS_SOCKET_UNIX_SOCKET_PATH={MFMODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket

--- a/adm/templates/plugins/mediation/{{cookiecutter.name}}/.layerapi2_extra_env
+++ b/adm/templates/plugins/mediation/{{cookiecutter.name}}/.layerapi2_extra_env
@@ -1,1 +1,1 @@
-REDIS_SOCKET_UNIX_SOCKET_PATH={MODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket
+REDIS_SOCKET_UNIX_SOCKET_PATH={MFMODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket

--- a/adm/templates/plugins/node/{{cookiecutter.name}}/.layerapi2_extra_env
+++ b/adm/templates/plugins/node/{{cookiecutter.name}}/.layerapi2_extra_env
@@ -1,1 +1,1 @@
-REDIS_SOCKET_UNIX_SOCKET_PATH={MODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket
+REDIS_SOCKET_UNIX_SOCKET_PATH={MFMODULE_RUNTIME_HOME}/var/redis_plugin_{{cookiecutter.name}}.socket

--- a/config/Makefile
+++ b/config/Makefile
@@ -7,24 +7,24 @@ include $(MFCOM_HOME)/share/config_subdir.mk
 test:
 	layer_wrapper --layers=devtools@mfext noutf8.sh
 
-all:: $(MODULE_HOME)/config/circus.ini $(MODULE_HOME)/config/telegraf.conf
+all:: $(MFMODULE_HOME)/config/circus.ini $(MFMODULE_HOME)/config/telegraf.conf
 
-$(MODULE_HOME)/config/stats.lua: stats.lua
+$(MFMODULE_HOME)/config/stats.lua: stats.lua
 	layer_wrapper --layers=devtools@mfext -- test_globals_in_lua.sh $<
 	cp -f $< $@
 
-$(MODULE_HOME)/config/upstream_status.lua: upstream_status.lua
+$(MFMODULE_HOME)/config/upstream_status.lua: upstream_status.lua
 	layer_wrapper --layers=devtools@mfext -- test_globals_in_lua.sh $<
 	cp -f $< $@
 
-$(MODULE_HOME)/config/init_worker_by_lua.lua: init_worker_by_lua.lua
+$(MFMODULE_HOME)/config/init_worker_by_lua.lua: init_worker_by_lua.lua
 	layer_wrapper --layers=devtools@mfext -- test_globals_in_lua.sh $<
 	cp -f $< $@
 
-$(MODULE_HOME)/config/socket_updown.lua: socket_updown.lua
+$(MFMODULE_HOME)/config/socket_updown.lua: socket_updown.lua
 	layer_wrapper --layers=devtools@mfext -- test_globals_in_lua.sh $<
 	cp -f $< $@
 
-$(MODULE_HOME)/config/health.lua: health.lua
+$(MFMODULE_HOME)/config/health.lua: health.lua
 	layer_wrapper --layers=devtools@mfext -- test_globals_in_lua.sh $<
 	cp -f $< $@

--- a/config/circus.ini.custom
+++ b/config/circus.ini.custom
@@ -12,18 +12,18 @@ stop_children = True
 {% if MFSERV_NGINX_FLAG == "1" %}
 [watcher:nginx]
 cmd={{MFEXT_HOME}}/opt/openresty/nginx/sbin/nginx                               
-args=-p {{MODULE_RUNTIME_HOME}}/tmp/nginx_tmp_prefix -c {{MODULE_RUNTIME_HOME}}/tmp/config_auto/nginx.conf
+args=-p {{MFMODULE_RUNTIME_HOME}}/tmp/nginx_tmp_prefix -c {{MFMODULE_RUNTIME_HOME}}/tmp/config_auto/nginx.conf
 numprocesses = 1                                                                
 stdout_stream.class = FileStream                                                
-stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/nginx.log                  
+stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/nginx.log                  
 stderr_stream.class = FileStream                                                
-stderr_stream.filename = {{MODULE_RUNTIME_HOME}}/log/nginx.log                  
+stderr_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/nginx.log                  
 copy_env = True                                                                 
 autostart = True                                                                
 respawn = True                                                                  
 hooks.before_start=circus_hooks.before_start_shell                              
 hooks.after_stop=circus_hooks.after_stop_shell          
-working_dir = {{MODULE_RUNTIME_HOME}}/tmp
+working_dir = {{MFMODULE_RUNTIME_HOME}}/tmp
 async_kill = True
 stop_signal = SIGQUIT
 
@@ -31,18 +31,18 @@ stop_signal = SIGQUIT
 {% if MFSERV_ADMIN_SEND_NGINX_LOGS == "1" %}
 [watcher:jsonlog2elasticsearch]
 cmd=layer_wrapper
-args=--layers=monitoring@mfext -- jsonlog2elasticsearch --transform-func=jsonlog2elasticsearch_metwork_addon.transform_func {{MFSERV_ADMIN_HOSTNAME_IP}} {{MFSERV_ADMIN_ELASTICSEARCH_HTTP_PORT}} nginx-%Y.%m.%d {{MODULE_RUNTIME_HOME}}/log/nginx_access.log
+args=--layers=monitoring@mfext -- jsonlog2elasticsearch --transform-func=jsonlog2elasticsearch_metwork_addon.transform_func {{MFSERV_ADMIN_HOSTNAME_IP}} {{MFSERV_ADMIN_ELASTICSEARCH_HTTP_PORT}} nginx-%Y.%m.%d {{MFMODULE_RUNTIME_HOME}}/log/nginx_access.log
 numprocesses = 1                                                                
 stdout_stream.class = FileStream                                                
-stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/jsonlog2elasticsearch_nginx.log                  
+stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/jsonlog2elasticsearch_nginx.log                  
 stderr_stream.class = FileStream                                                
-stderr_stream.filename = {{MODULE_RUNTIME_HOME}}/log/jsonlog2elasticsearch_nginx.log
+stderr_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/jsonlog2elasticsearch_nginx.log
 copy_env = True                                                                 
 autostart = True                                                                
 respawn = True                                                                  
 hooks.before_start=circus_hooks.before_start_shell                              
 hooks.after_stop=circus_hooks.after_stop_shell          
-working_dir = {{MODULE_RUNTIME_HOME}}/tmp
+working_dir = {{MFMODULE_RUNTIME_HOME}}/tmp
 async_kill = True
 
 {% endif %}
@@ -51,17 +51,17 @@ async_kill = True
 
 {% if MFSERV_AUTORESTART_FLAG == "1" %}
 [watcher:conf_monitor]                                                          
-cmd={{MODULE_HOME}}/bin/mfserv_conf_monitor.py                                         
+cmd={{MFMODULE_HOME}}/bin/mfserv_conf_monitor.py                                         
 args=                                                                           
 numprocesses = 1                                                                
 stdout_stream.class = FileStream                                                
-stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/conf_monitor.stdout        
+stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/conf_monitor.stdout        
 stderr_stream.class = FileStream                                                
-stderr_stream.filename = {{MODULE_RUNTIME_HOME}}/log/conf_monitor.stderr        
+stderr_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/conf_monitor.stderr        
 copy_env = True                                                                 
 autostart = True                                                                
 respawn = True           
-working_dir = {{MODULE_RUNTIME_HOME}}/tmp
+working_dir = {{MFMODULE_RUNTIME_HOME}}/tmp
 stop_signal = 9
 hooks.before_start=circus_hooks.before_start_shell                              
 hooks.after_stop=circus_hooks.after_stop_shell          
@@ -82,8 +82,8 @@ respawn = True
 graceful_timeout = {{APP.graceful_timeout}}
 stdout_stream.class = FileStream
 stderr_stream.class = FileStream
-stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/circus.log
-stderr_stream.filename = {{MODULE_RUNTIME_HOME}}/log/circus.log
+stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/circus.log
+stderr_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/circus.log
 {% if APP.max_age > 0 -%}
 max_age = {{APP.max_age}}
 max_age_variance = {{APP.max_age}}
@@ -99,7 +99,7 @@ rlimit_{{key}} = {{value}}
 MFSERV_CURRENT_PLUGIN_DEBUG=1
 {% endif %}
 {% if PLUGIN.hot_swap_plugin %}
-MODULE_PLUGINS_BASE_DIR={{PLUGIN.hot_swap_home}}
+MFMODULE_PLUGINS_BASE_DIR={{PLUGIN.hot_swap_home}}
 {% endif %}
 {% endif %}
 
@@ -119,8 +119,8 @@ respawn = True
 graceful_timeout = {{EXTRA.graceful_timeout}}
 stdout_stream.class = FileStream
 stderr_stream.class = FileStream
-stdout_stream.filename = {{MODULE_RUNTIME_HOME}}/log/circus.log
-stderr_stream.filename = {{MODULE_RUNTIME_HOME}}/log/circus.log
+stdout_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/circus.log
+stderr_stream.filename = {{MFMODULE_RUNTIME_HOME}}/log/circus.log
 {% if EXTRA.max_age > 0 -%}
 max_age = {{EXTRA.max_age}}
 max_age_variance = {{EXTRA.max_age}}
@@ -136,7 +136,7 @@ rlimit_{{key}} = {{value}}
 MFSERV_CURRENT_PLUGIN_DEBUG=1
 {% endif %}
 {% if PLUGIN.hot_swap_plugin %}
-MODULE_PLUGINS_BASE_DIR={{PLUGIN.hot_swap_home}}
+MFMODULE_PLUGINS_BASE_DIR={{PLUGIN.hot_swap_home}}
 {% endif %}
 {% endif %}
 

--- a/config/config.ini
+++ b/config/config.ini
@@ -23,7 +23,7 @@ timeout=60
 logging=1
 
 # In which tmp directory nginx put big request bodies
-clientbody_temp_path=@@@MODULE_RUNTIME_HOME@@@/var/nginx2
+clientbody_temp_path=@@@MFMODULE_RUNTIME_HOME@@@/var/nginx2
 
 # If flag=0, do not start nginx (can be useful in very special use cases)
 flag=1
@@ -134,7 +134,7 @@ minimal_level[DEV]=DEBUG
 # duplicate some log messages in JSON to a specific file (for external monitoring tool)
 # If json_file value is:
 # null => the feature is desactivated
-# AUTO => the json_file is @@@MODULE_RUNTIME_HOME@@@/log/json_logs.log if
+# AUTO => the json_file is @@@MFMODULE_RUNTIME_HOME@@@/log/json_logs.log if
 #         [admin]/hostname != null else null (desactivated)
 json_file=AUTO
 
@@ -153,10 +153,10 @@ json_minimal_level=WARNING
 [circus]
 
 # Advanced settings, you shouldn't change this
-endpoint=ipc://@@@MODULE_RUNTIME_HOME@@@/var/circus.socket
+endpoint=ipc://@@@MFMODULE_RUNTIME_HOME@@@/var/circus.socket
 
 # Advanced settings, you shouldn't change this
-pubsub_endpoint=ipc://@@@MODULE_RUNTIME_HOME@@@/var/circus_pubsub.socket
+pubsub_endpoint=ipc://@@@MFMODULE_RUNTIME_HOME@@@/var/circus_pubsub.socket
 
 
 ####################

--- a/config/health.lua
+++ b/config/health.lua
@@ -1,4 +1,4 @@
-local status_file = os.getenv("MODULE_RUNTIME_HOME") .. "/var/status"
+local status_file = os.getenv("MFMODULE_RUNTIME_HOME") .. "/var/status"
 
 local function load_status()
     local f = io.open(status_file, "r")

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -2,29 +2,29 @@
 daemon off;
 worker_processes {{MFSERV_NGINX_WORKERS}};
 {% if MFSERV_LOG_MINIMAL_LEVEL == "DEBUG" %}
-error_log  {{MODULE_RUNTIME_HOME}}/log/nginx_error.log debug;
+error_log  {{MFMODULE_RUNTIME_HOME}}/log/nginx_error.log debug;
 {% else %}
-error_log  {{MODULE_RUNTIME_HOME}}/log/nginx_error.log error;
+error_log  {{MFMODULE_RUNTIME_HOME}}/log/nginx_error.log error;
 {% endif %}
-pid        {{MODULE_RUNTIME_HOME}}/var/nginx.pid;
+pid        {{MFMODULE_RUNTIME_HOME}}/var/nginx.pid;
 
 # Main Loop Configuration
 events {
     worker_connections  40000;
 }
 
-{% for item in MODULE_ENVIRONMENT %}
+{% for item in MFMODULE_ENVIRONMENT %}
 env {{item}};
 {%- endfor %}
 
 # HTTP Configuration
 http {
 
-    include       {{MODULE_RUNTIME_HOME}}/tmp/config_auto/mime.types;
+    include       {{MFMODULE_RUNTIME_HOME}}/tmp/config_auto/mime.types;
     default_type  text/plain;
     # FIXME: ugly hack with ~~~1 and ~~~~2 to circumvent nginxfmt problem with JSON
     log_format main escape=none '~~~1 "@timestamp": "$time_iso8601", "from": "$remote_addr", "method": "$request_method", "uri": "$request_uri", "duration": $request_time, "status": $status, "request_length": $request_length, "reply_length": $bytes_sent, "plugin": "$plugin", "request_id": "$request_id"$extra_log_format ~~~2';
-    access_log  {{MODULE_RUNTIME_HOME}}/log/nginx_access.log  main;
+    access_log  {{MFMODULE_RUNTIME_HOME}}/log/nginx_access.log  main;
     client_body_temp_path {{MFSERV_NGINX_CLIENTBODY_TEMP_PATH}};
     client_max_body_size {{MFSERV_NGINX_UPLOAD_MAX_BODY_SIZE}}m;
     server_names_hash_bucket_size 1024;

--- a/config/redis_plugin_xxx.conf
+++ b/config/redis_plugin_xxx.conf
@@ -7,7 +7,7 @@ timeout 600
 tcp-keepalive 10
 save ""
 dbfilename redis_plugin_{{PLUGIN_NAME}}.rdb
-dir {{MODULE_RUNTIME_HOME}}/var/
-unixsocket {{MODULE_RUNTIME_HOME}}/var/redis_plugin_{{PLUGIN_NAME}}.socket
+dir {{MFMODULE_RUNTIME_HOME}}/var/
+unixsocket {{MFMODULE_RUNTIME_HOME}}/var/redis_plugin_{{PLUGIN_NAME}}.socket
 maxmemory 512mb
 maxmemory-policy allkeys-lru

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -9,7 +9,7 @@ def get_version():
     """
     :return: # The short X.Y version.
     """
-    return ".".join(os.environ.get('MODULE_VERSION',
+    return ".".join(os.environ.get('MFMODULE_VERSION',
                                    'unknown.unknown').split('.')[0:-1])
 
 
@@ -17,7 +17,7 @@ def get_release():
     """
     :return: the full version, including alpha/beta/rc tags
     """
-    return os.environ.get('MODULE_VERSION', 'unknown')
+    return os.environ.get('MFMODULE_VERSION', 'unknown')
 
 
 def build_intersphinx_mapping_url(current_module, module):

--- a/doc/mfserv_create_plugins.md
+++ b/doc/mfserv_create_plugins.md
@@ -26,7 +26,7 @@ You can also configure your plugin anytime by **editing the** `mfserv/{PLUGIN_NA
 
 You may need to customize the :index:configuration of your plugin (application). In order to do this, set your parameter(s) in the MFSERV module configuration file `config/config.ini`. This configuration file can contain a section per plugin. The section must be named `[plugin_{plugin_name}]`.
 
-Each parameter will be will transform into an environment variable whose pattern is `{MODULE}_{SECTION_NAME}_{PARAMETER_NAME}`.
+Each parameter will be will transform into an environment variable whose pattern is `{MFMODULE}_{SECTION_NAME}_{PARAMETER_NAME}`.
 
 .. note::
     - Environment variables are always in uppercase.

--- a/doc/mfserv_deploy_plugin.md
+++ b/doc/mfserv_deploy_plugin.md
@@ -12,13 +12,13 @@ make release
 Then a `{plugin name}-{version}-1.metwork.mfserv.plugin` file is created, where:
 
 - {plugin name} is the name of the plugin
-- `{version}` is the value of the `version` parameter defined in the plugin `config.ini` file you enter when you create the plugin (default value is `${MODULE_VERSION}`)
+- `{version}` is the value of the `version` parameter defined in the plugin `config.ini` file you enter when you create the plugin (default value is `${MFMODULE_VERSION}`)
  
 
 You can change the `version` in  plugin `config.ini` file:
 ```cfg
 # Version of the plugin (X.Y.Z)
-# If the value is [MODULE_VERSION],
+# If the value is [MFMODULE_VERSION],
 # the current module version is used
 version=1.0.0
 ```

--- a/doc/mfserv_miscellaneous.md
+++ b/doc/mfserv_miscellaneous.md
@@ -152,9 +152,9 @@ In order to (re)load the contab file:
 If you need to execute your `cron` command in the Metwork context, you should use the cron wrapper script `${MFSERV_HOME}/bin/cronwrap.sh`, e.g. :
 ```cfg
 {% raw %}
-{{MFSERV_HOME}}/bin/cronwrap.sh --lock --low "find {{MODULE_RUNTIME_HOME}}/var/archive/ -type f -mtime +5 -exec rm -f {} \;" >/dev/null 2>&1
+{{MFSERV_HOME}}/bin/cronwrap.sh --lock --low "find {{MFMODULE_RUNTIME_HOME}}/var/archive/ -type f -mtime +5 -exec rm -f {} \;" >/dev/null 2>&1
 
-{{MFSERV_HOME}}/bin/cronwrap.sh -- plugin_wrapper [your_plugin_name]  [your_sh_command] >{{MODULE_RUNTIME_HOME}}/log/[your_log_filename] 2>&1
+{{MFSERV_HOME}}/bin/cronwrap.sh -- plugin_wrapper [your_plugin_name]  [your_sh_command] >{{MFMODULE_RUNTIME_HOME}}/log/[your_log_filename] 2>&1
 {% endraw %}
 ```
 

--- a/doc/mfserv_quick_start.md
+++ b/doc/mfserv_quick_start.md
@@ -185,10 +185,10 @@ To do this, go to the `foo_default` plugin directory and enter the command:
 make release
 ```
 
-This will create a `.plugin` file that will be used to deploy the plugin, e.g. `foo_default-[version]-1.metwork.mfserv.plugin` where `[version]` is the value of the `version` parameter of the move_image `config.ini` you enter when you create the plugin (default value is `${MODULE_VERSION}`). You may change it:
+This will create a `.plugin` file that will be used to deploy the plugin, e.g. `foo_default-[version]-1.metwork.mfserv.plugin` where `[version]` is the value of the `version` parameter of the move_image `config.ini` you enter when you create the plugin (default value is `${MFMODULE_VERSION}`). You may change it:
 ```cfg
 # Version of the plugin (X.Y.Z)
-# If the value is [MODULE_VERSION],
+# If the value is [MFMODULE_VERSION],
 # the current module version is used
 version=1.0.0
 ```

--- a/layers/layer1_python2/0500_extra_python_packages/Makefile.mk
+++ b/layers/layer1_python2/0500_extra_python_packages/Makefile.mk
@@ -2,11 +2,11 @@ include ../../../adm/root.mk
 
 include $(MFEXT_HOME)/share/python2_layer.mk
 
-#before:: $(MODULE_HOME)/opt/$(LAYER_NAME)/.layerapi2_label
+#before:: $(MFMODULE_HOME)/opt/$(LAYER_NAME)/.layerapi2_label
 
-#$(MODULE_HOME)/opt/$(LAYER_NAME)/.layerapi2_label:
-#	bootstrap_layer.sh python2@mfserv $(MODULE_HOME)/opt/python2
-#	echo "root@mfserv" >$(MODULE_HOME)/opt/python2/.layerapi2_dependencies
-#	echo "python2@mfcom" >>$(MODULE_HOME)/opt/python2/.layerapi2_dependencies
+#$(MFMODULE_HOME)/opt/$(LAYER_NAME)/.layerapi2_label:
+#	bootstrap_layer.sh python2@mfserv $(MFMODULE_HOME)/opt/python2
+#	echo "root@mfserv" >$(MFMODULE_HOME)/opt/python2/.layerapi2_dependencies
+#	echo "python2@mfcom" >>$(MFMODULE_HOME)/opt/python2/.layerapi2_dependencies
 toto:
 	pip freeze

--- a/layers/layer1_python3/0500_extra_python_packages/Makefile.mk
+++ b/layers/layer1_python3/0500_extra_python_packages/Makefile.mk
@@ -2,9 +2,9 @@ include ../../../adm/root.mk
 
 include $(MFEXT_HOME)/share/python3_layer.mk
 
-#before:: $(MODULE_HOME)/opt/$(LAYER_NAME)/.layerapi2_label
+#before:: $(MFMODULE_HOME)/opt/$(LAYER_NAME)/.layerapi2_label
 
-#$(MODULE_HOME)/opt/$(LAYER_NAME)/.layerapi2_label:
-#	bootstrap_layer.sh python3@mfserv $(MODULE_HOME)/opt/python3
-#	echo "root@mfserv" >$(MODULE_HOME)/opt/python3/.layerapi2_dependencies
-#	echo "python3@mfcom" >>$(MODULE_HOME)/opt/python3/.layerapi2_dependencies
+#$(MFMODULE_HOME)/opt/$(LAYER_NAME)/.layerapi2_label:
+#	bootstrap_layer.sh python3@mfserv $(MFMODULE_HOME)/opt/python3
+#	echo "root@mfserv" >$(MFMODULE_HOME)/opt/python3/.layerapi2_dependencies
+#	echo "python3@mfcom" >>$(MFMODULE_HOME)/opt/python3/.layerapi2_dependencies

--- a/layers/layer1_python3/0700_aiohttp_metwork_middlewares/aiohttp_metwork_middlewares/__init__.py
+++ b/layers/layer1_python3/0700_aiohttp_metwork_middlewares/aiohttp_metwork_middlewares/__init__.py
@@ -4,8 +4,8 @@ from mflog import get_logger
 from async_timeout import timeout
 
 
-MODULE = os.environ['MODULE']
-CURRENT_PLUGIN_NAME_ENV_VAR = "%s_CURRENT_PLUGIN_NAME" % MODULE
+MFMODULE = os.environ['MFMODULE']
+CURRENT_PLUGIN_NAME_ENV_VAR = "%s_CURRENT_PLUGIN_NAME" % MFMODULE
 if CURRENT_PLUGIN_NAME_ENV_VAR in os.environ:
     PLUGIN = os.environ[CURRENT_PLUGIN_NAME_ENV_VAR]
 else:

--- a/plugins/welcome/config.ini
+++ b/plugins/welcome/config.ini
@@ -11,9 +11,9 @@
 name=welcome
 
 # Version of the plugin (X.Y.Z)
-# If the value is {{MODULE_VERSION}},
+# If the value is {{MFMODULE_VERSION}},
 # the current module version is used
-version={{MODULE_VERSION}}
+version={{MFMODULE_VERSION}}
 
 # Summary (one line) of the goal of the plugin
 summary=welcome plugin for mfserv


### PR DESCRIPTION
…E_HOME becomes MFMODULE_HOME and so on)

BREAKING CHANGE: old variables names are no longer defined, they should not be used anymore (be careful with existing plugins)