### PR TITLE
feat: load resty.core in nginx conf

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -56,6 +56,7 @@ http {
     # (this is a feature of commercial nginx version emulated in lua here)
     lua_shared_dict peers 10m;
     init_worker_by_lua_block {
+        require("resty.core") -- required by lua-resty-limit-traffic (count)
         require("init_worker_by_lua")()
     }
 


### PR DESCRIPTION
you need this if you use resty.limit.count lua module for example