### PR TITLE
fix: remove rlimit_core (because of `ulimit -c 0` in mfext)

### DIFF
--- a/adm/templates/plugins/_common/config.ini
+++ b/adm/templates/plugins/_common/config.ini
@@ -256,13 +256,11 @@ add_app_dir_to_python_path=false
 # rlimit_nofile => maximum number of open file descriptors for the current worker.
 # rlimit_stack => maximum size (in bytes) of the call stack for the current worker.
 #     This only affects the stack of the main thread in a multi-threaded worker.
-# rlimit_core => maximum size (in bytes) of a core file that the current worker can create.
 # rlimit_fsize =>  maximum size of a file which the worker may create.
 # (empty value means no limit)
 rlimit_as = 1000000000
 rlimit_nofile = 1000
 rlimit_stack = 10000000
-rlimit_core = 100000
 rlimit_fsize = 100000000
 {% endblock %}
 
@@ -307,7 +305,6 @@ log_split_multiple_workers=AUTO
 # rlimit_as = 1000000000
 # rlimit_nofile = 1000
 # rlimit_stack = 10000000
-# rlimit_core = 100000
 # rlimit_fsize = 100000000
 # log_split_stdout_stderr=AUTO
 # log_split_multiple_workers=AUTO

--- a/config/circus.ini.custom
+++ b/config/circus.ini.custom
@@ -62,7 +62,9 @@ max_age_variance = {{APP.max_age}}
 
 {% endif -%}
 {% for key, value in APP.rlimits.items()|sort() %}
+{% if key != "core" -%}
 rlimit_{{key}} = {{value}}
+{% endif -%}
 {% endfor %}
 
 {% if APP.debug or PLUGIN.hot_swap_prefix != "" %}
@@ -97,7 +99,9 @@ max_age_variance = {{EXTRA.max_age}}
 
 {% endif -%}
 {% for key, value in EXTRA.rlimits.items()|sort() %}
+{% if key != "core" -%}
 rlimit_{{key}} = {{value}}
+{% endif -%}
 {% endfor %}
 
 {% if PLUGIN.hot_swap_plugin %}

--- a/doc/mfserv_tuning_monitoring.md
+++ b/doc/mfserv_tuning_monitoring.md
@@ -23,13 +23,11 @@ You are able to control resource limits for each app workers of a plugin by sett
 # rlimit_nofile => maximum number of open file descriptors for the current worker.
 # rlimit_stack => maximum size (in bytes) of the call stack for the current worker.
 #     This only affects the stack of the main thread in a multi-threaded worker.
-# rlimit_core => maximum size (in bytes) of a core file that the current worker can create.
 # rlimit_fsize =>  maximum size of a file which the worker may create.
 # (empty value means no limit)
 rlimit_as = 1000000000
 rlimit_nofile = 1000
 rlimit_stack = 10000000
-rlimit_core = 100000
 rlimit_fsize = 100000000
 ```
 


### PR DESCRIPTION
close mfserv part of #684