### PR TITLE
feat: remove absolute log paths from log_proxy usages (LOGPROXY_LOG_D…

### DIFF
--- a/.metwork-framework/cheatsheet.md
+++ b/.metwork-framework/cheatsheet.md
@@ -92,7 +92,7 @@ As `mfserv` unix user:
 | --- | --- |
 | **`config.ini`** | main plugin configuration file |
 | **`Makefile`** | build configuration file (you probably don't need to touch this unless you have specific build directives to add to the `custom::` target) |
-| `crontab` | plugin crontab (use something like `* * * * * {{MFSERV_HOME}}/bin/cronwrap.sh -l -e -- plugin_wrapper {YOUR_PLUGIN_NAME} {YOUR_COMMAND} >>{{MODULE_RUNTIME_HOME}}/log/your_command.log 2>&1` for each line to execute your command in your plugin environement) |
+| `crontab` | plugin crontab (use something like `* * * * * {{MFSERV_HOME}}/bin/cronwrap.sh -l -e -- plugin_wrapper {YOUR_PLUGIN_NAME} {YOUR_COMMAND} >>your_command.log 2>&1` for each line to execute your command in your plugin environement) |
 | `local/` | local subdirectory (it mainly holds the python virtualenv), never touch this it's automatically generated) |
 | `bin/` | if you put an executable in this directory, it will be available in `PATH` (in your plugin environment) |
 | `lib/` | thie library directory will be available in `LD_LIBRARY_PATH` and in `PYTHONPATH` (in your plugin environment), so you can put here shared libraries or python files you want to include easily |

--- a/.metwork-framework/cheatsheet.md
+++ b/.metwork-framework/cheatsheet.md
@@ -92,7 +92,7 @@ As `mfserv` unix user:
 | --- | --- |
 | **`config.ini`** | main plugin configuration file |
 | **`Makefile`** | build configuration file (you probably don't need to touch this unless you have specific build directives to add to the `custom::` target) |
-| `crontab` | plugin crontab (use something like `* * * * * {{MFSERV_HOME}}/bin/cronwrap.sh -l -e -- plugin_wrapper {YOUR_PLUGIN_NAME} {YOUR_COMMAND} >>your_command.log 2>&1` for each line to execute your command in your plugin environement) |
+| `crontab` | plugin crontab (use something like `* * * * * {{MFSERV_HOME}}/bin/cronwrap.sh -l -e -- plugin_wrapper {YOUR_PLUGIN_NAME} {YOUR_COMMAND} >>{{MODULE_RUNTIME_HOME}}/log/your_command.log 2>&1` for each line to execute your command in your plugin environement) |
 | `local/` | local subdirectory (it mainly holds the python virtualenv), never touch this it's automatically generated) |
 | `bin/` | if you put an executable in this directory, it will be available in `PATH` (in your plugin environment) |
 | `lib/` | thie library directory will be available in `LD_LIBRARY_PATH` and in `PYTHONPATH` (in your plugin environment), so you can put here shared libraries or python files you want to include easily |

--- a/adm/templates/plugins/_common/crontab
+++ b/adm/templates/plugins/_common/crontab
@@ -1,3 +1,3 @@
 # Your crontab fragment here
 # Example:
-# 0 2 * * * {% raw %}{{MFSERV_HOME}}{% endraw %}/bin/cronwrap.sh --lock --log-capture-to {% raw %}{{MFMODULE_RUNTIME_HOME}}{% endraw %}/log/your_command.log -- plugin_wrapper {{cookiecutter.name}} your_command.sh
+# 0 2 * * * {% raw %}{{MFSERV_HOME}}{% endraw %}/bin/cronwrap.sh --lock --log-capture-to your_command.log -- plugin_wrapper {{cookiecutter.name}} your_command.sh

--- a/config/circus.ini.custom
+++ b/config/circus.ini.custom
@@ -12,7 +12,7 @@ stop_children = True
 {% if MFSERV_NGINX_FLAG == "1" %}
 [watcher:nginx]
 cmd=log_proxy_wrapper
-args={% if MFSERV_NGINX_MAX_SIZE_BEFORE_ROTATION|int > 0 %}--rotation-size {{MFSERV_NGINX_MAX_SIZE_BEFORE_ROTATION}} {% endif %}--stdout {{MFMODULE_RUNTIME_HOME}}/log/nginx_access.log --stderr {{MFMODULE_RUNTIME_HOME}}/log/nginx_error.log -- {{MFEXT_HOME}}/opt/openresty/nginx/sbin/nginx -p {{MFMODULE_RUNTIME_HOME}}/tmp/nginx_tmp_prefix -c {{MFMODULE_RUNTIME_HOME}}/tmp/config_auto/nginx.conf
+args={% if MFSERV_NGINX_MAX_SIZE_BEFORE_ROTATION|int > 0 %}--rotation-size {{MFSERV_NGINX_MAX_SIZE_BEFORE_ROTATION}} {% endif %}--stdout nginx_access.log --stderr nginx_error.log -- {{MFEXT_HOME}}/opt/openresty/nginx/sbin/nginx -p {{MFMODULE_RUNTIME_HOME}}/tmp/nginx_tmp_prefix -c {{MFMODULE_RUNTIME_HOME}}/tmp/config_auto/nginx.conf
 numprocesses = 1                                                                
 copy_env = True                                                                 
 autostart = True                                                                
@@ -28,7 +28,7 @@ max_retry = -1
 {% if MFSERV_AUTORESTART_FLAG == "1" %}
 [watcher:conf_monitor]                                                          
 cmd=log_proxy_wrapper
-args=--stdout {{MFMODULE_RUNTIME_HOME}}/log/conf_monitor.log --stderr STDOUT -- {{MFMODULE_HOME}}/bin/mfserv_conf_monitor.py
+args=--stdout conf_monitor.log --stderr STDOUT -- {{MFMODULE_HOME}}/bin/mfserv_conf_monitor.py
 numprocesses = 1                                                                
 copy_env = True                                                                 
 autostart = True                                                                

--- a/doc/mfserv_miscellaneous.md
+++ b/doc/mfserv_miscellaneous.md
@@ -154,7 +154,7 @@ If you need to execute your `cron` command in the Metwork context, you should us
 {% raw %}
 {{MFSERV_HOME}}/bin/cronwrap.sh --lock --low "find {{MFMODULE_RUNTIME_HOME}}/var/archive/ -type f -mtime +5 -exec rm -f {} \;" >/dev/null 2>&1
 
-{{MFSERV_HOME}}/bin/cronwrap.sh -- plugin_wrapper [your_plugin_name]  [your_sh_command] >{{MFMODULE_RUNTIME_HOME}}/log/[your_log_filename] 2>&1
+{{MFSERV_HOME}}/bin/cronwrap.sh -- plugin_wrapper [your_plugin_name]  [your_sh_command] >[your_log_filename] 2>&1
 {% endraw %}
 ```
 

--- a/doc/mfserv_miscellaneous.md
+++ b/doc/mfserv_miscellaneous.md
@@ -154,7 +154,7 @@ If you need to execute your `cron` command in the Metwork context, you should us
 {% raw %}
 {{MFSERV_HOME}}/bin/cronwrap.sh --lock --low "find {{MFMODULE_RUNTIME_HOME}}/var/archive/ -type f -mtime +5 -exec rm -f {} \;" >/dev/null 2>&1
 
-{{MFSERV_HOME}}/bin/cronwrap.sh -- plugin_wrapper [your_plugin_name]  [your_sh_command] >{{MODULE_RUNTIME_HOME}}/log/[your_log_filename] 2>&1
+{{MFSERV_HOME}}/bin/cronwrap.sh -- plugin_wrapper [your_plugin_name]  [your_sh_command] --log-capture-to [your_log_filename] 2>&1
 {% endraw %}
 ```
 

--- a/doc/mfserv_miscellaneous.md
+++ b/doc/mfserv_miscellaneous.md
@@ -154,7 +154,7 @@ If you need to execute your `cron` command in the Metwork context, you should us
 {% raw %}
 {{MFSERV_HOME}}/bin/cronwrap.sh --lock --low "find {{MFMODULE_RUNTIME_HOME}}/var/archive/ -type f -mtime +5 -exec rm -f {} \;" >/dev/null 2>&1
 
-{{MFSERV_HOME}}/bin/cronwrap.sh -- plugin_wrapper [your_plugin_name]  [your_sh_command] --log-capture-to [your_log_filename] 2>&1
+{{MFSERV_HOME}}/bin/cronwrap.sh --log-capture-to [your_log_filename] -- plugin_wrapper [your_plugin_name]  [your_sh_command]
 {% endraw %}
 ```
 

--- a/doc/mfserv_miscellaneous.md
+++ b/doc/mfserv_miscellaneous.md
@@ -154,7 +154,7 @@ If you need to execute your `cron` command in the Metwork context, you should us
 {% raw %}
 {{MFSERV_HOME}}/bin/cronwrap.sh --lock --low "find {{MFMODULE_RUNTIME_HOME}}/var/archive/ -type f -mtime +5 -exec rm -f {} \;" >/dev/null 2>&1
 
-{{MFSERV_HOME}}/bin/cronwrap.sh -- plugin_wrapper [your_plugin_name]  [your_sh_command] >[your_log_filename] 2>&1
+{{MFSERV_HOME}}/bin/cronwrap.sh -- plugin_wrapper [your_plugin_name]  [your_sh_command] >{{MODULE_RUNTIME_HOME}}/log/[your_log_filename] 2>&1
 {% endraw %}
 ```
 


### PR DESCRIPTION
…IRECTORY env variable is used by default)

(mfserv part of https://github.com/metwork-framework/resources/issues/54)