### PR TITLE
feat: remove all references to MFCOM or mfcom, including backward com…

### DIFF
--- a/adm/__make_nginx_conf
+++ b/adm/__make_nginx_conf
@@ -19,19 +19,9 @@ MFSERV_PLUGINS_HOME = os.path.join(MFMODULE_RUNTIME_HOME,
 MFSERV_PLUGINS_HOTSWAP_HOME = os.path.join(MFMODULE_RUNTIME_HOME,
                                            "tmp", "plugins.hotswap")
 MFSERV_NGINX_TIMEOUT = int(os.environ['MFSERV_NGINX_TIMEOUT'])
-HOSTNAME = os.environ.get('MFCOM_HOSTNAME')
-HOSTNAME_FULL = os.environ.get('MFCOM_HOSTNAME_FULL')
+HOSTNAME = os.environ.get('MFHOSTNAME')
+HOSTNAME_FULL = os.environ.get('MFHOSTNAME_FULL')
 MFMODULE = os.environ['MFMODULE']
-
-# FIXME: fix to ensure compatibility with existing plugins using
-# old variables names MODULE* (to be removed)
-for var in ["MODULE", "MODULE_HOME", "MODULE_LOWERCASE", "MODULE_VERSION",
-            "MODULE_STATUS", "MODULE_RUNTIME_HOME", "MODULE_RUNTIME_USER",
-            "MODULE_RUNTIME_SUFFIX", "MODULE_PLUGINS_BASE_DIR"]:
-    new_var = 'MF' + var
-    if var not in os.environ and new_var in os.environ:
-        os.environ[var] = os.environ[new_var]
-
 
 LOGGER = get_logger("__make_nginx_conf")
 

--- a/adm/templates/plugins/_common/config.ini
+++ b/adm/templates/plugins/_common/config.ini
@@ -146,10 +146,10 @@ smart_start_delay=3
 
 {% block app_workers %}
 # number of workers / processes
-# note: you can use {% raw %}{{MFCOM_HARDWARE_NUMBER_OF_CPU_CORES_MULTIPLIED_BY_2}}{% endraw %} value
+# note: you can use {% raw %}{{MFHARDWARE_NUMBER_OF_CPU_CORES_MULTIPLIED_BY_2}}{% endraw %} value
 # to avoid a kind of hardware automatic value (see "env |grep HARDWARE" as mfserv
 # to find other automatic values)
-numprocesses={% raw %}{{MFCOM_HARDWARE_NUMBER_OF_CPU_CORES_MULTIPLIED_BY_2}}{% endraw %}
+numprocesses={% raw %}{{MFHARDWARE_NUMBER_OF_CPU_CORES_MULTIPLIED_BY_2}}{% endraw %}
 
 {% endblock %}
 

--- a/config/config.ini.custom
+++ b/config/config.ini.custom
@@ -16,9 +16,9 @@ port=18868
 upload_max_body_size=100
 
 # Number of nginx workers
-# (the {{MFCOM_HARDWARE_NUMBER_OF_CPU_CORES_MULTIPLIED_BY_2}} special values
+# (the {{MFHARDWARE_NUMBER_OF_CPU_CORES_MULTIPLIED_BY_2}} special values
 #  is probably a good start)
-workers={{MFCOM_HARDWARE_NUMBER_OF_CPU_CORES_MULTIPLIED_BY_2}}
+workers={{MFHARDWARE_NUMBER_OF_CPU_CORES_MULTIPLIED_BY_2}}
 
 # Default timeout (in seconds)
 # You can override this in plugin config.ini


### PR DESCRIPTION
…patibility stuff

BREAKING_CHANGE: Backward compatibility is broken for old plugins