### PR TITLE
fix: django, duplicated logs (#579)

### DIFF
--- a/adm/templates/plugins/python3_django3/{{cookiecutter.name}}/postinstall
+++ b/adm/templates/plugins/python3_django3/{{cookiecutter.name}}/postinstall
@@ -47,6 +47,17 @@ GDAL_LIBRARY_PATH = MFEXT_HOME + '/opt/scientific_core/lib/libgdal.so'
 GEOS_LIBRARY_PATH = MFEXT_HOME + '/opt/scientific_core/lib/libgeos_c.so'
 SPATIALITE_LIBRARY_PATH = MFEXT_HOME + '/opt/scientific_core/lib/mod_spatialite.so'
 
+# TO PROVIDE MFLOG LOGGING ONLY
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "loggers": {
+        "django": {
+            "propagate": True,
+        },
+    },
+}
+
 # TO PROVIDE PREFIX BASED ROUTING
 STATIC_URL = '/{{cookiecutter.name}}/static/'
 STATIC_ROOT = Path(BASE_DIR, "main/static")


### PR DESCRIPTION
Fix "django.*" log duplication.

Way to reproduce the bug:

```
docker run -it metwork/mfservplugins-centos8-buildimage:release_2.1 /bin/bash
su - mfserv
bootstrap_plugin.py create --template python3_django3 mydjango
cd mydjango/
make develop
mfserv.start
cat ~/log/app_mydjango_main.log 
# trigger a django.request error
curl -X POST http://localhost:18868/mydjango/
# check log
cat ~/log/app_mydjango_main.log 
# => django logs are duplicated, one with mflog format, and one without format
```


