### PR TITLE
fix: fix plugin python3_raw_asgi

### DIFF
--- a/adm/templates/plugins/python3_raw_asgi/{{cookiecutter.name}}/python3_virtualenv_sources/requirements-to-freeze.txt
+++ b/adm/templates/plugins/python3_raw_asgi/{{cookiecutter.name}}/python3_virtualenv_sources/requirements-to-freeze.txt
@@ -1,3 +1,5 @@
 # python3 requirements.txt file
 # see https://pip.readthedocs.io/en/1.1/requirements.html
 uvicorn>=0.11,<0.12
+#uvloop >= 0.18.0 is not ok with centos6
+uvloop<0.17.0


### PR DESCRIPTION
(recent uvloop wheels are not compatible with centos6)