### PR TITLE
feat: bump django to 5.2.2 (to fix CVE-2025-48432)

### DIFF
--- a/adm/templates/plugins/python3_django/{{cookiecutter.name}}/python3_virtualenv_sources/requirements-to-freeze.txt
+++ b/adm/templates/plugins/python3_django/{{cookiecutter.name}}/python3_virtualenv_sources/requirements-to-freeze.txt
@@ -1,6 +1,7 @@
 # python3 requirements.txt file
 # see https://pip.readthedocs.io/en/1.1/requirements.html
-#django4 should be >= 4.2.20 and django5 should be >= 5.0.14 or >= 5.1.7
-#to fix CVE-2024-53908, CVE-2024-53907, CVE-2024-56374, CVE-2025-26699
-#and CVE-2025-27556
-django>=5.0.14
+#django4 should be >= 4.2.22 (LTS) and django5 should be >= 5.1.10 or >= 5.2.2 (LTS)
+#to fix CVE-2024-53908, CVE-2024-53907, CVE-2024-56374, CVE-2025-26699,
+#CVE-2025-27556 and CVE-2025-48432
+#django 5.0 (5.0.14) has reach its eol
+django>=5.2.2


### PR DESCRIPTION
(5.1.10 would be ok too)