### PR TITLE
fix: problem initializing php-fpm with multiple apps plugin

### DIFF
--- a/adm/php_wrapper
+++ b/adm/php_wrapper
@@ -7,8 +7,8 @@
 #   $3 : unix socket path used to tell with php-fpm process
 
 export MFMODULE_RUNTIME_GROUP=metwork
-export PHPFPMCONF=${MFMODULE_RUNTIME_HOME}/tmp/config_auto/php-fpm."$1".conf
-export WWWCONF=${MFMODULE_RUNTIME_HOME}/tmp/config_auto/www."$1".conf
+export PHPFPMCONF=${MFMODULE_RUNTIME_HOME}/tmp/config_auto/php-fpm."$1"_"$2".conf
+export WWWCONF=${MFMODULE_RUNTIME_HOME}/tmp/config_auto/www."$1"_"$2".conf
 export PHP_SOCKET_PATH="$3"
 export PHP_LOGFILE_PATH=${MFMODULE_RUNTIME_HOME}/log/app_"$1"_"$2".log
 


### PR DESCRIPTION
Change names of php-fpm initialization files to distinguish each app of a plugin in the php_wrapper.