### PR TITLE
feat: bump django minimal version to 5.2.13 in plugin django3

### DIFF
--- a/adm/templates/plugins/python3_django/{{cookiecutter.name}}/python3_virtualenv_sources/requirements-to-freeze.txt
+++ b/adm/templates/plugins/python3_django/{{cookiecutter.name}}/python3_virtualenv_sources/requirements-to-freeze.txt
@@ -1,9 +1,10 @@
 # python3 requirements.txt file
 # see https://pip.readthedocs.io/en/1.1/requirements.html
-#django4 should be >= 4.2.29 (LTS) and django5 should be >= 5.2.12 (LTS)
+#django4 should be >= 4.2.30 (LTS) and django5 should be >= 5.2.13 (LTS)
 #to fix CVE-2024-53908, CVE-2024-53907, CVE-2024-56374, CVE-2025-26699,
 #CVE-2025-27556, CVE-2025-48432, CVE-2025-57833, CVE-2025-59681, CVE-2025-64458,
 #CVE-2025-64459, CVE-2025-64460, CVE-2025-13372, CVE-2026-1207, CVE-2026-1287,
-#CVE-2026-1312, CVE-2026-25673 and CVE-2026-25674
+#CVE-2026-1312, CVE-2026-25673, CVE-2026-25674, CVE-2026-3902, CVE-2026-33034,
+#CVE-2026-33033, CVE-2026-4292 and CVE-2026-4277
 #django 5.0 (5.0.14) and 5.1 (5.1.15) have reach their eol
-django>=5.2.12
+django>=5.2.13


### PR DESCRIPTION
CVE fixed :
- CVE-2026-3902 (high)
- CVE-2026-33034 (high)
- CVE-2026-33033 (moderate)
- CVE-2026-4292 (low)
- CVE-2026-4277 (low)