### PR TITLE
fix: Django package name from pypi.org

### DIFF
--- a/adm/templates/plugins/python3_django/{{cookiecutter.name}}/python3_virtualenv_sources/requirements-to-freeze.txt
+++ b/adm/templates/plugins/python3_django/{{cookiecutter.name}}/python3_virtualenv_sources/requirements-to-freeze.txt
@@ -7,4 +7,4 @@
 #CVE-2026-1312, CVE-2026-25673, CVE-2026-25674, CVE-2026-3902, CVE-2026-33034,
 #CVE-2026-33033, CVE-2026-4292 and CVE-2026-4277
 #django 5.0 (5.0.14) and 5.1 (5.1.15) have reach their eol
-django>=5.2.13
+Django>=5.2.13


### PR DESCRIPTION
Right package name from pypi.org is Django with "D" as uppercase. cf. https://pypi.org/project/Django/
Today, using a recent version of Nexus Repository Manager used as python pypi proxy, in our company, "django" is no more resolved as "Django". So it should be better to declare "Django".